### PR TITLE
[FIXED JENKINS-27880] Expose value field for NodeLabelParameters

### DIFF
--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterValue.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterValue.java
@@ -181,6 +181,7 @@ public class LabelParameterValue extends ParameterValue {
     /**
      * @return the label
      */
+    @Exported(name = "value")
     public String getLabel() {
         return label;
     }


### PR DESCRIPTION
This allows the label value to be exposed in REST API calls with the key 'value'.