### PR TITLE
[JENKINS-28374] Update NodeParameterDefinition.java to handle rebuilds via Rebuild-Plugin

### DIFF
--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition.java
@@ -230,7 +230,7 @@ public class NodeParameterDefinition extends SimpleParameterDefinition implement
         // as JSONArray: {"name":"HOSTN","value":["master","host2"]}
         // as String from script: {"name":"HOSTN","value":"master"}
         final String name = jo.getString("name");
-        final Object joValue = jo.get("value") == null ? jo.get("labels") : jo.get("value");
+        final Object joValue = jo.get("value") == null ? (jo.get("labels") == null ? jo.get("label") : jo.get("labels")) : jo.get("value");
 
         List<String> nodes = new ArrayList<String>();
         if (joValue instanceof String) {


### PR DESCRIPTION
When passing the Node definition from a parent job to a child job, the child job cannot be rebuilt using the Rebuild-Plugin as the field with the value in is name 'label' rather than the expected 'labels'. 

Addition of extra case to try to use 'label' if neither 'value' or 'labels' can be found.