### PR TITLE
[JENKINS-32939] changed the constructor when asking for default value.

### DIFF
--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinition.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinition.java
@@ -97,7 +97,7 @@ public class LabelParameterDefinition extends SimpleParameterDefinition implemen
 
 	@Override
 	public LabelParameterValue getDefaultParameterValue() {
-		return new LabelParameterValue(getName(), getDescription(), defaultValue);
+	    return new LabelParameterValue(getName(), defaultValue, allNodesMatchingLabel, nodeEligibility);
 	}
 	
 	public boolean isAllNodesMatchingLabel() {


### PR DESCRIPTION
Solved the issue: When triggered by timer, Job with "NodeLabel Parameter Plugin" does not build in parallel on all nodes which share a label. Was using a wrong constructor when getDefaultValue was called.

@imod please, it'd be great if you can review the change. Thanks.

@reviewbybees 