### PR TITLE
Use value as the parameter element, instead of labels

### DIFF
--- a/src/main/resources/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinition/index.jelly
+++ b/src/main/resources/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinition/index.jelly
@@ -31,7 +31,7 @@ THE SOFTWARE.
 		<!-- this div is required because of ParametersDefinitionProperty.java#117 -->
 		<div name="parameter" description="${it.description}">
 			<input type="hidden" name="name" value="${it.name}" />
-			<f:textbox name="label" value="${it.defaultValue}" />
+			<f:textbox name="value" value="${it.defaultValue}" />
 		</div>
 	</f:entry>	
     <j:set var="descriptor" value="${it.descriptor}"/>

--- a/src/main/resources/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition/index.jelly
+++ b/src/main/resources/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition/index.jelly
@@ -34,7 +34,7 @@ THE SOFTWARE.
 			
 			<j:choose>
 				<j:when test="${it.allowMultiNodeSelection == true}">
-					<select name="labels" multiple="multiple" size="${it.allowedNodesOrAll.size()}">
+					<select name="value" multiple="multiple" size="${it.allowedNodesOrAll.size()}">
 						<j:forEach var="aNode" items="${it.allowedNodesOrAll}"
 							varStatus="loop">
 							<j:choose>
@@ -49,7 +49,7 @@ THE SOFTWARE.
 					</select>
 				</j:when>
 				<j:otherwise>
-					<select name="labels">
+					<select name="value">
 						<j:forEach var="aNode" items="${it.allowedNodesOrAll}" varStatus="loop">
 							<j:choose>
 								<j:when test="${it.defaultSlaves.contains(aNode)}">


### PR DESCRIPTION
Hi, 

In order to support using NodeLabel parameters in Active Choices plug-in, we can either try to add special logic to support NodeLabel parameters, or try to make the plug-in behave similar to other parameters.

A choice parameter in Jenkins creates the following HTML.

```
<div name="parameter">
  <input name="name" value="CCC" type="hidden">
  <select name="value"><option value="1">1</option><option value="2">2</option><option value="3">3</option><option value="4">4</option></select></div>
```

But the NodeLabel parameter creates the following HTML.

```
<div description="" name="parameter">
  <input name="name" value="NODES_PARAM" type="hidden">
  <select name="labels"><option value="master">master</option><option value="manga">manga</option><option value="test1">test1</option></select></div>
```

The main difference is the select name, which instead of "value" is "labels" for the NodeLabel parameter. It gets interpreted correctly in Jenkins later, when the job is executed. But since active choices inspects HTML DOM to retrieve values, it is not compatible with the NodeLabel plug-in.

I've quickly tested it, and the Node parameter was correctly passed to the build when using value instead of labels. But I also noticed JENKINS-28374, and parts of the code like this https://github.com/jenkinsci/nodelabelparameter-plugin/blob/db037f2e2586e545c57399ce32e2b7436772b8e3/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition.java#L228

So not entirely sure it wouldn't cause a regression in the plug-in. What do you think @imod?

Cheers
Bruno