### PR TITLE
[JENKINS-33746] Start parallel jobs even if running on master

### DIFF
--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/wrapper/TriggerNextBuildWrapper.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/wrapper/TriggerNextBuildWrapper.java
@@ -89,7 +89,7 @@ public class TriggerNextBuildWrapper extends BuildWrapper {
 				if (nextNodes != null) {
 					for (String nextNode : nextNodes) {
 						// Avoid to add the current node again
-						if (!StringUtils.isBlank(initialBuildNode) && !initialBuildNode.equals(nextNode)) {
+						if (initialBuildNode != null && !initialBuildNode.equals(nextNode)) {
 							newBuildNodes.add(nextNode);
 						}
 					}


### PR DESCRIPTION
On the master node, getBuiltOnStr() returns the empty string. triggerAllBuildsConcurrent does not trigger any concurrent builds if initalBuildNode is "blank", which includes being the empty string.

https://issues.jenkins-ci.org/browse/JENKINS-33746