### PR TITLE
Replace jquery with jquery3-api plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.javadoc.skip>true</maven.javadoc.skip>
-                <revision>1.8.2</revision>
+                <revision>1.9.0</revision>
                 <changelist>-SNAPSHOT</changelist>
                 <jenkins.version>2.263.1</jenkins.version>
                 <java.level>8</java.level>

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
 			<artifactId>token-macro</artifactId>
 		</dependency>
 		<dependency>
-		    <groupId>org.jenkins-ci.plugins</groupId>
-		    <artifactId>jquery</artifactId>
+			<groupId>io.jenkins.plugins</groupId>
+			<artifactId>jquery3-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.main</groupId>


### PR DESCRIPTION
## Replace jquery dependency with jquery3-api plugin

Assumes that jquery3 has enough compatibility for the Javascript needed here.

Interactive testing and test automation detected no issue with this change.  Behavior is the same as the previous releases and this removes one of the dependencies on the outdated jquery API plugin.

Would greatly appreciate a review from someone with real Javascript experience, like @uhafner.  See the Javascript source at https://github.com/jenkinsci/nodelabelparameter-plugin/blob/master/src/main/webapp/lib/nodelabel.js and the references to that source at https://github.com/jenkinsci/nodelabelparameter-plugin/blob/ea0a822f3a09423eb32eee9d5496ce7a14b4a931/src/main/resources/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition/config.jelly#L32 and at https://github.com/jenkinsci/nodelabelparameter-plugin/blob/ea0a822f3a09423eb32eee9d5496ce7a14b4a931/src/main/resources/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinition/config.jelly#L32
