### PR TITLE
Use https:// instead of git:// as pom scm URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
 	<url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 	<scm>
-		<connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+		<connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
 		<developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
 		<url>https://github.com/${gitHubRepo}</url>
 	  <tag>${scmTag}</tag>


### PR DESCRIPTION
## Use https:// instead of git:// in pom SCM URL

GitHub is deprecating git:// protocol
