### PR TITLE
Require Jenkins 2.289.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <maven.javadoc.skip>true</maven.javadoc.skip>
                 <revision>1.9.3</revision>
                 <changelist>-SNAPSHOT</changelist>
-                <jenkins.version>2.263.1</jenkins.version>
+                <jenkins.version>2.289.1</jenkins.version>
                 <java.level>8</java.level>
                 <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 	</properties>
@@ -97,7 +97,7 @@
                 <dependencies>
                         <dependency>
                                 <groupId>io.jenkins.tools.bom</groupId>
-                                <artifactId>bom-2.263.x</artifactId>
+                                <artifactId>bom-2.289.x</artifactId>
                                 <version>950.v396cb834de1e</version>
                                 <type>pom</type>
                                 <scope>import</scope>


### PR DESCRIPTION
## Require Jenkins 2.289.1

The token macro updates to support more recent asm versions are important parts of the testing and use of this plugin.  Newer token macro plugin versions require 2.289.1.  This updates to use 2.289.1 so that the newer token macro version is used for tests.

2.289.1 is the current recommendation of
https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline
