### PR TITLE
Fix coverage reporting with pom 4.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-                <version>4.27</version>
+                <version>4.28</version>
                 <relativePath />
 	</parent>
 


### PR DESCRIPTION
## Fix coverage reporting with pom 4.28

Plugin pom 4.27 inadvertently disabled coverage reporting.
