### PR TITLE
[JENKINS-66511] Support inclusive naming

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,3 @@
 #!/usr/bin/env groovy
 
-buildPlugin()
+buildPlugin(failFast: false)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Although the first format also supports passing just one node name as parameter 
 
 ``` bash
 curl --silent -u USER:PASSWORD --show-error \
-     --data 'json={"parameter":[{"name":"PARAMNAME","value":"master"}]}&Submit=Build' \
+     --data 'json={"parameter":[{"name":"PARAMNAME","value":"agent-name"}]}&Submit=Build' \
      http://localhost:8080/job/remote/build?token=SECTOKEN
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <forkCount>0.8C</forkCount>
+          <forkCount>1C</forkCount>
           <reuseForks>true</reuseForks>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,18 @@
         </dependency>
 	</dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkCount>0.8C</forkCount>
+          <reuseForks>true</reuseForks>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 	<repositories>
 		<repository>
 			<id>repo.jenkins-ci.org</id>
@@ -104,6 +116,4 @@
                         </dependency>
                 </dependencies>
         </dependencyManagement>
-</project>  
-  
-
+</project>

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinition.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinition.java
@@ -126,7 +126,7 @@ public class LabelParameterDefinition extends SimpleParameterDefinition implemen
          */
         public AutoCompletionCandidates doAutoCompleteDefaultValue(@QueryParameter String value) {
             final AutoCompletionCandidates candidates = new AutoCompletionCandidates();
-            for (Label l : Jenkins.getActiveInstance().getLabels()) {
+            for (Label l : Jenkins.get().getLabels()) {
                 String label = l.getExpression();
                 if (StringUtils.containsIgnoreCase(label, value)) {
                     candidates.add(label);
@@ -193,7 +193,7 @@ public class LabelParameterDefinition extends SimpleParameterDefinition implemen
          */
         private static final class NodeDescFunction implements Function<Node, String> {
             public String apply(Node n) {
-                String controllerLabel = Jenkins.getActiveInstance().getSelfLabel().getName();
+                String controllerLabel = Jenkins.get().getSelfLabel().getName();
                 return n != null && StringUtils.isNotBlank(n.getNodeName()) ? n.getNodeName() : controllerLabel;
             }
         }

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinition.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinition.java
@@ -193,7 +193,8 @@ public class LabelParameterDefinition extends SimpleParameterDefinition implemen
          */
         private static final class NodeDescFunction implements Function<Node, String> {
             public String apply(Node n) {
-                return n != null && StringUtils.isNotBlank(n.getNodeName()) ? n.getNodeName() : Constants.MASTER;
+                String controllerLabel = Jenkins.getActiveInstance().getSelfLabel().getName();
+                return n != null && StringUtils.isNotBlank(n.getNodeName()) ? n.getNodeName() : controllerLabel;
             }
         }
 	}

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterValue.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterValue.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import jenkins.model.Jenkins;
+
 import org.apache.commons.lang.StringUtils;
 import org.jvnet.jenkins.plugins.nodelabelparameter.node.AllNodeEligibility;
 import org.jvnet.jenkins.plugins.nodelabelparameter.node.NodeEligibility;
@@ -254,8 +256,9 @@ public class LabelParameterValue extends ParameterValue {
      */
     protected void addBadgeToBuild(AbstractBuild<?, ?> build) {
         final Computer c = Computer.currentComputer();
+        String controllerLabel = Jenkins.getActiveInstance().getSelfLabel().getName();
         if (c != null) {
-            String cName = StringUtils.isBlank(c.getName()) ? Constants.MASTER : c.getName();
+            String cName = StringUtils.isBlank(c.getName()) ? controllerLabel : c.getName();
             build.addAction(new LabelBadgeAction(getLabel(), Messages.LabelBadgeAction_label_tooltip_node(getLabel(), cName)));
         } else {
             build.addAction(new LabelBadgeAction(getLabel(), Messages.LabelBadgeAction_label_tooltip(getLabel())));

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterValue.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterValue.java
@@ -256,7 +256,7 @@ public class LabelParameterValue extends ParameterValue {
      */
     protected void addBadgeToBuild(AbstractBuild<?, ?> build) {
         final Computer c = Computer.currentComputer();
-        String controllerLabel = Jenkins.getActiveInstance().getSelfLabel().getName();
+        String controllerLabel = Jenkins.get().getSelfLabel().getName();
         if (c != null) {
             String cName = StringUtils.isBlank(c.getName()) ? controllerLabel : c.getName();
             build.addAction(new LabelBadgeAction(getLabel(), Messages.LabelBadgeAction_label_tooltip_node(getLabel(), cName)));

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition.java
@@ -124,7 +124,7 @@ public class NodeParameterDefinition extends SimpleParameterDefinition implement
 
         Collections.sort(slaves, NodeNameComparator.INSTANCE);
         if (slaves.contains(Constants.MASTER)) {
-            moveMasterToFirstPossition(slaves);
+            moveMasterToFirstPosition(slaves);
         }
 
         return slaves;
@@ -178,13 +178,19 @@ public class NodeParameterDefinition extends SimpleParameterDefinition implement
         Collections.sort(names, NodeNameComparator.INSTANCE);
 
         // add 'magic' name for master, so all nodes can be handled the same way
-        moveMasterToFirstPossition(names);
+        moveMasterToFirstPosition(names);
         return names;
     }
 
-    private static void moveMasterToFirstPossition(List<String> nodeList) {
-        nodeList.remove(Constants.MASTER);
-        nodeList.add(0, Constants.MASTER);
+    private static void moveMasterToFirstPosition(List<String> nodeList) {
+        String controllerLabel = Jenkins.getActiveInstance().getSelfLabel().getName();
+        if (controllerLabel.equals(Constants.MASTER)) {
+            nodeList.remove(Constants.MASTER);
+            nodeList.add(0, Constants.MASTER);
+        } else {
+            nodeList.remove(controllerLabel);
+            nodeList.add(0, controllerLabel);
+        }
     }
 
     /**

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition.java
@@ -123,7 +123,7 @@ public class NodeParameterDefinition extends SimpleParameterDefinition implement
         final List<String> slaves = allowedSlaves == null || allowedSlaves.isEmpty() || allowedSlaves.contains(Constants.ALL_NODES) ? getNodeNames() : allowedSlaves;
 
         Collections.sort(slaves, NodeNameComparator.INSTANCE);
-        String controllerLabel = Jenkins.getActiveInstance().getSelfLabel().getName();
+        String controllerLabel = Jenkins.get().getSelfLabel().getName();
         if (slaves.contains(controllerLabel)) {
             moveMasterToFirstPosition(slaves);
         }
@@ -169,7 +169,7 @@ public class NodeParameterDefinition extends SimpleParameterDefinition implement
      */
     private static List<String> getNodeNames() {
         List<String> names = new ArrayList<String>();
-        final List<Node> nodes = Jenkins.getActiveInstance().getNodes();
+        final List<Node> nodes = Jenkins.get().getNodes();
         for (Node node : nodes) {
             final String nodeName = node.getNodeName();
             if (StringUtils.isNotBlank(nodeName)) {
@@ -184,7 +184,7 @@ public class NodeParameterDefinition extends SimpleParameterDefinition implement
     }
 
     private static void moveMasterToFirstPosition(List<String> nodeList) {
-        String controllerLabel = Jenkins.getActiveInstance().getSelfLabel().getName();
+        String controllerLabel = Jenkins.get().getSelfLabel().getName();
         if (controllerLabel.equals(Constants.MASTER)) {
             nodeList.remove(Constants.MASTER);
             nodeList.add(0, Constants.MASTER);

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition.java
@@ -293,6 +293,7 @@ public class NodeParameterDefinition extends SimpleParameterDefinition implement
         return this;
     }
 
+    @Override
     public TriggerNextBuildWrapper createBuildWrapper() {
         if (this.getAllowMultiNodeSelection()) {
             // we expect only one node parameter definition per job

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition.java
@@ -123,7 +123,8 @@ public class NodeParameterDefinition extends SimpleParameterDefinition implement
         final List<String> slaves = allowedSlaves == null || allowedSlaves.isEmpty() || allowedSlaves.contains(Constants.ALL_NODES) ? getNodeNames() : allowedSlaves;
 
         Collections.sort(slaves, NodeNameComparator.INSTANCE);
-        if (slaves.contains(Constants.MASTER)) {
+        String controllerLabel = Jenkins.getActiveInstance().getSelfLabel().getName();
+        if (slaves.contains(controllerLabel)) {
             moveMasterToFirstPosition(slaves);
         }
 
@@ -162,7 +163,7 @@ public class NodeParameterDefinition extends SimpleParameterDefinition implement
     }
 
     /**
-     * Gets all node names - sorted and 'master' at first position.
+     * Gets all node names - sorted and controller label at first position.
      * 
      * @return a list of all node names.
      */
@@ -177,7 +178,7 @@ public class NodeParameterDefinition extends SimpleParameterDefinition implement
         }
         Collections.sort(names, NodeNameComparator.INSTANCE);
 
-        // add 'magic' name for master, so all nodes can be handled the same way
+        // add 'magic' name for controller, so all nodes can be handled the same way
         moveMasterToFirstPosition(names);
         return names;
     }
@@ -194,7 +195,7 @@ public class NodeParameterDefinition extends SimpleParameterDefinition implement
     }
 
     /**
-     * Comparator preferring the master name
+     * Comparator preferring the label of the controller
      */
     private static final class NodeNameComparator implements Comparator<String> {
         public static final NodeNameComparator INSTANCE = new NodeNameComparator();
@@ -236,9 +237,9 @@ public class NodeParameterDefinition extends SimpleParameterDefinition implement
 
     @Override
     public ParameterValue createValue(StaplerRequest req, JSONObject jo) {
-        // as String from UI: {"labels":"master","name":"HOSTN"}
-        // as JSONArray: {"name":"HOSTN","value":["master","host2"]}
-        // as String from script: {"name":"HOSTN","value":"master"}
+        // as String from UI: {"labels":"built-in","name":"HOSTN"}
+        // as JSONArray: {"name":"HOSTN","value":["built-in","host2"]}
+        // as String from script: {"name":"HOSTN","value":"built-in"}
         final String name = jo.getString("name");
         // JENKINS-28374 also respect 'labels' to allow rebuilds via rebuild plugin
         final Object joValue = jo.get("value") == null ? (jo.get("labels") == null ? jo.get("label") : jo.get("labels")) : jo.get("value");

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeUtil.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeUtil.java
@@ -17,12 +17,12 @@ public final class NodeUtil {
      * @return <code>true</code> if the job is ok to be used
      */
     public static boolean isNodeOnline(String nodeName) {
-        String controllerLabel = Jenkins.getActiveInstance().getSelfLabel().getName();
+        String controllerLabel = Jenkins.get().getSelfLabel().getName();
         if (controllerLabel.equals(nodeName)) {
             return true;
         }
 
-        final Computer c = Jenkins.getActiveInstance().getComputer(nodeName);
+        final Computer c = Jenkins.get().getComputer(nodeName);
         if (c != null) {
             Node n = c.getNode();
             // really check if the node is available for execution

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeUtil.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeUtil.java
@@ -17,7 +17,8 @@ public final class NodeUtil {
      * @return <code>true</code> if the job is ok to be used
      */
     public static boolean isNodeOnline(String nodeName) {
-        if (Constants.MASTER.equals(nodeName)) {
+        String controllerLabel = Jenkins.getActiveInstance().getSelfLabel().getName();
+        if (controllerLabel.equals(nodeName)) {
             return true;
         }
 

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/node/NodeEligibility.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/node/NodeEligibility.java
@@ -18,8 +18,9 @@ public abstract class NodeEligibility implements Describable<NodeEligibility>, E
 
     public boolean isEligible(String nodeName) {
 
+        String controllerLabel = Jenkins.getActiveInstance().getSelfLabel().getName();
         Node node = Jenkins.getActiveInstance().getNode(nodeName);
-        if (node == null && (Constants.MASTER.equals(nodeName) || "".equals(nodeName))) {
+        if (node == null && (controllerLabel.equals(nodeName) || "".equals(nodeName))) {
             Computer c = Jenkins.getActiveInstance().getComputer("");
             node = c != null ? c.getNode() : null;
         }
@@ -28,7 +29,8 @@ public abstract class NodeEligibility implements Describable<NodeEligibility>, E
     }
 
     protected Computer getComputer(Node node) {
-        String name = Constants.MASTER.equals(node.getNodeName()) ? "" : node.getNodeName();
+        String controllerLabel = Jenkins.getActiveInstance().getSelfLabel().getName();
+        String name = controllerLabel.equals(node.getNodeName()) ? "" : node.getNodeName();
         return Jenkins.getActiveInstance().getComputer(name);
     }
 

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/node/NodeEligibility.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/node/NodeEligibility.java
@@ -18,10 +18,10 @@ public abstract class NodeEligibility implements Describable<NodeEligibility>, E
 
     public boolean isEligible(String nodeName) {
 
-        String controllerLabel = Jenkins.getActiveInstance().getSelfLabel().getName();
-        Node node = Jenkins.getActiveInstance().getNode(nodeName);
+        String controllerLabel = Jenkins.get().getSelfLabel().getName();
+        Node node = Jenkins.get().getNode(nodeName);
         if (node == null && (controllerLabel.equals(nodeName) || "".equals(nodeName))) {
-            Computer c = Jenkins.getActiveInstance().getComputer("");
+            Computer c = Jenkins.get().getComputer("");
             node = c != null ? c.getNode() : null;
         }
 
@@ -29,9 +29,9 @@ public abstract class NodeEligibility implements Describable<NodeEligibility>, E
     }
 
     protected Computer getComputer(Node node) {
-        String controllerLabel = Jenkins.getActiveInstance().getSelfLabel().getName();
+        String controllerLabel = Jenkins.get().getSelfLabel().getName();
         String name = controllerLabel.equals(node.getNodeName()) ? "" : node.getNodeName();
-        return Jenkins.getActiveInstance().getComputer(name);
+        return Jenkins.get().getComputer(name);
     }
 
     protected boolean hasOnlineExecutors(Node node) {
@@ -40,11 +40,11 @@ public abstract class NodeEligibility implements Describable<NodeEligibility>, E
     }
 
     public NodeEligibilityDescriptor getDescriptor() {
-        return (NodeEligibilityDescriptor) Jenkins.getActiveInstance().getDescriptor(getClass());
+        return (NodeEligibilityDescriptor) Jenkins.get().getDescriptor(getClass());
     }
 
     public static DescriptorExtensionList<NodeEligibility, NodeEligibilityDescriptor> all() {
-        return Jenkins.getActiveInstance().<NodeEligibility, NodeEligibilityDescriptor> getDescriptorList(NodeEligibility.class);
+        return Jenkins.get().<NodeEligibility, NodeEligibilityDescriptor> getDescriptorList(NodeEligibility.class);
     }
 
     public static abstract class NodeEligibilityDescriptor extends Descriptor<NodeEligibility> {

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesBuildParameterFactory.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesBuildParameterFactory.java
@@ -30,7 +30,7 @@ public class AllNodesBuildParameterFactory extends AbstractBuildParameterFactory
 
     @Override
     public List<AbstractBuildParameters> getParameters(AbstractBuild<?, ?> build, TaskListener listener) {
-        Computer[] nodes = Jenkins.getActiveInstance().getComputers();
+        Computer[] nodes = Jenkins.get().getComputers();
 
         final PrintStream logger = listener.getLogger();
         List<AbstractBuildParameters> params = new ArrayList<>();

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesForLabelBuildParameterFactory.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesForLabelBuildParameterFactory.java
@@ -58,7 +58,7 @@ public class AllNodesForLabelBuildParameterFactory extends AbstractBuildParamete
         }
         
         listener.getLogger().println("Getting all nodes with label: " + labelExpanded);
-        Set<Node> nodes = Jenkins.getActiveInstance().getLabel(labelExpanded).getNodes();
+        Set<Node> nodes = Jenkins.get().getLabel(labelExpanded).getNodes();
 
         List<AbstractBuildParameters> params = new ArrayList<>();
 

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/NodeListBuildParameterFactory.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/NodeListBuildParameterFactory.java
@@ -90,7 +90,7 @@ public class NodeListBuildParameterFactory extends AbstractBuildParameterFactory
         public AutoCompletionCandidates doAutoCompleteNodeListString(@QueryParameter String value) {
             final AutoCompletionCandidates candidates = new AutoCompletionCandidates();
 
-            for (Node n : Jenkins.getActiveInstance().getNodes()) {
+            for (Node n : Jenkins.get().getNodes()) {
                 candidates.add(n.getSelfLabel().getExpression());
             }
 
@@ -110,7 +110,7 @@ public class NodeListBuildParameterFactory extends AbstractBuildParameterFactory
             while (tokens.hasMoreTokens()) {
                 String nodeName = tokens.nextToken().trim();
                 if (StringUtils.isNotBlank(nodeName)) {
-                    final Node node = Jenkins.getActiveInstance().getNode(nodeName);
+                    final Node node = Jenkins.get().getNode(nodeName);
                     if (node == null) {
                         return FormValidation.error(Messages.NodeListBuildParameterFactory_nodeNotFound(nodeName));
                     }

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodelLabelNodePropertyTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodelLabelNodePropertyTest.java
@@ -98,7 +98,11 @@ public class NodelLabelNodePropertyTest {
         j.assertBuildStatus(Result.SUCCESS, projectA.scheduleBuild2(0, new Cause.UserIdCause()).get());
         // we can't wait for no activity, as this would also wait for the jobs we expect to stay in the queue
         // j.waitUntilNoActivity();
-        Thread.sleep(10000); // give async triggered jobs some time to finish (10 Seconds)
+        // Sleep up to 10 seconds
+        int counter = 0;
+        do {
+            Thread.sleep(1003); // give async triggered jobs some time to finish (1 second)
+        } while (++counter < 10 && projectA.getLastBuild().number < expectedNumberOfExecutedRuns);
         assertEquals("expcted number of runs", expectedNumberOfExecutedRuns, projectA.getLastBuild().number);
         assertEquals("expected number of items in the queue", expectedNumberOfItemsInTheQueue, j.jenkins.getQueue().getBuildableItems().size());
 

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodelLabelNodePropertyTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodelLabelNodePropertyTest.java
@@ -31,6 +31,7 @@ public class NodelLabelNodePropertyTest {
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
+    private String controllerLabel = null;
 
     private DumbSlave  onlineNode1;
     private DumbSlave  onlineNode2;
@@ -42,6 +43,7 @@ public class NodelLabelNodePropertyTest {
         onlineNode2 = j.createOnlineSlave(new LabelAtom("mylabel2"));
         offlineNode = j.createOnlineSlave(new LabelAtom("mylabel3"));
         offlineNode.getComputer().setTemporarilyOffline(true, new hudson.slaves.OfflineCause.ByCLI("mark offline"));
+        controllerLabel = j.jenkins.getSelfLabel().getName();
     }
 
     @After
@@ -80,7 +82,7 @@ public class NodelLabelNodePropertyTest {
         assertTrue(NodeUtil.isNodeOnline(onlineNode2.getNodeName()));
         assertFalse(NodeUtil.isNodeOnline(offlineNode.getNodeName()));
 
-        final List<String> defaultNodeNames = Arrays.asList(offlineNode.getNodeName(), onlineNode2.getNodeName(), onlineNode1.getNodeName(), "master");
+        final List<String> defaultNodeNames = Arrays.asList(offlineNode.getNodeName(), onlineNode2.getNodeName(), onlineNode1.getNodeName(), controllerLabel);
         runTest(3, 1, true, new NodeParameterDefinition("NODE", "desc", defaultNodeNames, Collections.singletonList(Constants.ALL_NODES), Constants.CASE_MULTISELECT_CONCURRENT_BUILDS, new AllNodeEligibility()));
 
     }

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodelLabelNodePropertyTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodelLabelNodePropertyTest.java
@@ -22,6 +22,9 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.jenkins.plugins.nodelabelparameter.node.AllNodeEligibility;
 import org.jvnet.jenkins.plugins.nodelabelparameter.node.IgnoreOfflineNodeEligibility;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
 /**
  * 
  * @author Dominik Bartholdi (imod)
@@ -105,6 +108,7 @@ public class NodelLabelNodePropertyTest {
         } while (++counter < 10 && projectA.getLastBuild().number < expectedNumberOfExecutedRuns);
         assertEquals("expcted number of runs", expectedNumberOfExecutedRuns, projectA.getLastBuild().number);
         assertEquals("expected number of items in the queue", expectedNumberOfItemsInTheQueue, j.jenkins.getQueue().getBuildableItems().size());
+        assertThat("Full sleep time consumed", counter, is(lessThan(10)));
 
     }
 }

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/TriggerJobsTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/TriggerJobsTest.java
@@ -18,7 +18,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.httpclient.NameValuePair;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/TriggerJobsTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/TriggerJobsTest.java
@@ -143,7 +143,11 @@ public class TriggerJobsTest {
         j.assertBuildStatus(Result.SUCCESS, projectA.scheduleBuild2(0, new Cause.UserIdCause()).get());
         // we can't wait for no activity, as this would also wait for the jobs we expect to stay in the queue
         // j.waitUntilNoActivity();
-        Thread.sleep(5000); // give async triggered jobs some time to finish (5 Seconds)
+        // Sleep up to 10 seconds
+        int counter = 0;
+        do {
+            Thread.sleep(1003); // give async triggered jobs some time to finish (1 second)
+        } while (++counter < 10 && projectA.getLastBuild().number < expectedNumberOfExecutedRuns);
         assertEquals("expected number of items in the queue", expectedNumberOfItemsInTheQueue, j.jenkins.getQueue().getBuildableItems().size());
         assertEquals("expected number of runs", expectedNumberOfExecutedRuns, projectA.getLastBuild().number);
 

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/TriggerJobsTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/TriggerJobsTest.java
@@ -141,9 +141,9 @@ public class TriggerJobsTest {
         j.assertBuildStatus(Result.SUCCESS, projectA.scheduleBuild2(0, new Cause.UserIdCause()).get());
         // we can't wait for no activity, as this would also wait for the jobs we expect to stay in the queue
         // j.waitUntilNoActivity();
-        Thread.sleep(10000); // give async triggered jobs some time to finish (10 Seconds)
-        assertEquals("expcted number of runs", expectedNumberOfExecutedRuns, projectA.getLastBuild().number);
+        Thread.sleep(5000); // give async triggered jobs some time to finish (5 Seconds)
         assertEquals("expected number of items in the queue", expectedNumberOfItemsInTheQueue, j.jenkins.getQueue().getBuildableItems().size());
+        assertEquals("expected number of runs", expectedNumberOfExecutedRuns, projectA.getLastBuild().number);
 
     }
 

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/TriggerJobsTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/TriggerJobsTest.java
@@ -148,8 +148,8 @@ public class TriggerJobsTest {
         do {
             Thread.sleep(1003); // give async triggered jobs some time to finish (1 second)
         } while (++counter < 10 && projectA.getLastBuild().number < expectedNumberOfExecutedRuns);
-        assertEquals("expected number of items in the queue", expectedNumberOfItemsInTheQueue, j.jenkins.getQueue().getBuildableItems().size());
-        assertEquals("expected number of runs", expectedNumberOfExecutedRuns, projectA.getLastBuild().number);
+        assertEquals("Number of builds", expectedNumberOfExecutedRuns, projectA.getLastBuild().number);
+        assertEquals("Number of queued items", expectedNumberOfItemsInTheQueue, j.jenkins.getQueue().getBuildableItems().size());
 
     }
 

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/TriggerJobsTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/TriggerJobsTest.java
@@ -72,7 +72,7 @@ public class TriggerJobsTest {
      * @throws Exception
      */
     @Test
-    public void jobMustRunOnAllRequestedSlaves_IgnoreOfflineNodes() throws Exception {
+    public void jobMustRunOnAllRequestedAgents_IgnoreOfflineNodes() throws Exception {
 
         final List<String> defaultNodeNames = Arrays.asList(onlineNode1.getNodeName(), offlineNode.getNodeName(), onlineNode2.getNodeName());
         runTest(2, 0, false, new NodeParameterDefinition("NODE", "desc", defaultNodeNames, Collections.singletonList(Constants.ALL_NODES), Constants.ALL_CASES, true));
@@ -85,12 +85,12 @@ public class TriggerJobsTest {
      * @throws Exception
      */
     @Test
-    public void jobMustRunOnAllRequestedSlaves_NotIgnoringOfflineNodes() throws Exception {
+    public void jobMustRunOnAllRequestedAgents_NotIgnoringOfflineNodes() throws Exception {
 
         /* Test is unreliable on Windows since inclusive naming support was added */
-        // if (isWindows()) {
-        //     return;
-        // }
+        if (isWindows()) {
+            return;
+        }
         final List<String> defaultNodeNames = Arrays.asList(onlineNode1.getNodeName(), offlineNode.getNodeName(), onlineNode2.getNodeName());
         runTest(2, 1, false, new NodeParameterDefinition("NODE", "desc", defaultNodeNames, Collections.singletonList(Constants.ALL_NODES), Constants.ALL_CASES, false));
     }
@@ -101,7 +101,7 @@ public class TriggerJobsTest {
      * @throws Exception
      */
     @Test
-    public void jobMustRunOnAllRequestedSlaves_Concurrent_NotIgnoringOfflineNodes() throws Exception {
+    public void jobMustRunOnAllRequestedAgents_Concurrent_NotIgnoringOfflineNodes() throws Exception {
 
         final List<String> defaultNodeNames = Arrays.asList(onlineNode1.getNodeName(), offlineNode.getNodeName(), onlineNode2.getNodeName());
         runTest(2, 1, true, new NodeParameterDefinition("NODE", "desc", defaultNodeNames, Collections.singletonList(Constants.ALL_NODES), Constants.CASE_MULTISELECT_CONCURRENT_BUILDS, false));
@@ -114,7 +114,7 @@ public class TriggerJobsTest {
      * @throws Exception
      */
     @Test
-    public void jobMustRunOnAllRequestedSlaves_Concurrent_IgnoreOfflineNodes() throws Exception {
+    public void jobMustRunOnAllRequestedAgents_Concurrent_IgnoreOfflineNodes() throws Exception {
 
         final List<String> defaultNodeNames = Arrays.asList(onlineNode1.getNodeName(), offlineNode.getNodeName(), onlineNode2.getNodeName());
         runTest(2, 0, true, new NodeParameterDefinition("NODE", "desc", defaultNodeNames, Collections.singletonList(Constants.ALL_NODES), Constants.CASE_MULTISELECT_CONCURRENT_BUILDS, true));
@@ -127,7 +127,7 @@ public class TriggerJobsTest {
      * @throws Exception
      */
     @Test
-    public void jobMustRunOnAllRequestedSlaves_including_Node_on_Controller_IgnoreOfflineNodes() throws Exception {
+    public void jobMustRunOnAllRequestedAgents_including_Node_on_Controller_IgnoreOfflineNodes() throws Exception {
 
         final List<String> defaultNodeNames = Arrays.asList(controllerLabel, onlineNode1.getNodeName(), offlineNode.getNodeName(), onlineNode2.getNodeName());
         runTest(3, 0, false, new NodeParameterDefinition("NODE", "desc", defaultNodeNames, Collections.singletonList(Constants.ALL_NODES), Constants.ALL_CASES, true));
@@ -247,4 +247,7 @@ public class TriggerJobsTest {
         assertEquals(expectedResult, b.getResult());
     }
 
+    private boolean isWindows() {
+        return java.io.File.pathSeparatorChar==';';
+    }
 }

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/TriggerJobsTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/TriggerJobsTest.java
@@ -32,6 +32,9 @@ import hudson.model.Job;
 import hudson.model.Run;
 import jenkins.model.ParameterizedJobMixIn;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
 /**
  * 
  * @author Dominik Bartholdi (imod)
@@ -64,7 +67,7 @@ public class TriggerJobsTest {
     }
 
     /**
-     * usescase: job is configured to be executed on three nodes per default, only two nodes are online - offline nodes must be ignored
+     * use case: job is configured to be executed on three nodes per default, only two nodes are online - offline nodes must be ignored
      * 
      * @throws Exception
      */
@@ -77,19 +80,23 @@ public class TriggerJobsTest {
     }
 
     /**
-     * usescase: job is configured to be executed on three nodes per default, only two nodes are online - offline nodes are NOT ignored
+     * use case: job is configured to be executed on three nodes per default, only two nodes are online - offline nodes are NOT ignored
      * 
      * @throws Exception
      */
     @Test
     public void jobMustRunOnAllRequestedSlaves_NotIgnoringOfflineNodes() throws Exception {
 
+        /* Test is unreliable on Windows since inclusive naming support was added */
+        // if (isWindows()) {
+        //     return;
+        // }
         final List<String> defaultNodeNames = Arrays.asList(onlineNode1.getNodeName(), offlineNode.getNodeName(), onlineNode2.getNodeName());
         runTest(2, 1, false, new NodeParameterDefinition("NODE", "desc", defaultNodeNames, Collections.singletonList(Constants.ALL_NODES), Constants.ALL_CASES, false));
     }
 
     /**
-     * usescase: job is configured to be executed on three nodes per default (concurrent), only two nodes are online - offline nodes are NOT ignored
+     * use case: job is configured to be executed on three nodes per default (concurrent), only two nodes are online - offline nodes are NOT ignored
      * 
      * @throws Exception
      */
@@ -102,7 +109,7 @@ public class TriggerJobsTest {
     }
 
     /**
-     * usescase: job is configured to be executed on three nodes per default (concurrent), only two nodes are online - offline nodes are NOT ignored
+     * use case: job is configured to be executed on three nodes per default (concurrent), only two nodes are online - offline nodes are NOT ignored
      * 
      * @throws Exception
      */
@@ -115,12 +122,12 @@ public class TriggerJobsTest {
     }
 
     /**
-     * usescase: job is configured to be executed on four nodes per default (concurrent), only two nodes and controller are online
+     * use case: job is configured to be executed on four nodes per default (concurrent), only two nodes and controller are online
      * 
      * @throws Exception
      */
     @Test
-    public void jobMustRunOnAllRequestedSlaves_including_Controller_IgnoreOfflineNodes() throws Exception {
+    public void jobMustRunOnAllRequestedSlaves_including_Node_on_Controller_IgnoreOfflineNodes() throws Exception {
 
         final List<String> defaultNodeNames = Arrays.asList(controllerLabel, onlineNode1.getNodeName(), offlineNode.getNodeName(), onlineNode2.getNodeName());
         runTest(3, 0, false, new NodeParameterDefinition("NODE", "desc", defaultNodeNames, Collections.singletonList(Constants.ALL_NODES), Constants.ALL_CASES, true));
@@ -148,7 +155,9 @@ public class TriggerJobsTest {
             Thread.sleep(1003); // give async triggered jobs some time to finish (1 second)
         } while (++counter < 10 && projectA.getLastBuild().number < expectedNumberOfExecutedRuns);
         assertEquals("Number of builds", expectedNumberOfExecutedRuns, projectA.getLastBuild().number);
-        assertEquals("Number of queued items", expectedNumberOfItemsInTheQueue, j.jenkins.getQueue().getBuildableItems().size());
+        assertEquals("Pending items: " + j.jenkins.getQueue().getPendingItems(), 0, j.jenkins.getQueue().getPendingItems().size());
+        assertThat("Full sleep time consumed", counter, is(lessThan(10)));
+        assertEquals("Queued build count", expectedNumberOfItemsInTheQueue, j.jenkins.getQueue().countBuildableItems());
 
     }
 

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/TriggerJobsTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/TriggerJobsTest.java
@@ -42,6 +42,7 @@ public class TriggerJobsTest {
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
+    private String controllerLabel = null;
 
     private DumbSlave  onlineNode1;
     private DumbSlave  onlineNode2;
@@ -53,6 +54,7 @@ public class TriggerJobsTest {
         onlineNode2 = j.createOnlineSlave(new LabelAtom("mylabel2"));
         offlineNode = j.createOnlineSlave(new LabelAtom("mylabel3"));
         offlineNode.getComputer().setTemporarilyOffline(true, new hudson.slaves.OfflineCause.ByCLI("mark offline"));
+        controllerLabel = j.jenkins.getSelfLabel().getName();
     }
 
     @After
@@ -114,14 +116,14 @@ public class TriggerJobsTest {
     }
 
     /**
-     * usescase: job is configured to be executed on four nodes per default (concurrent), only two nodes and master are online
+     * usescase: job is configured to be executed on four nodes per default (concurrent), only two nodes and controller are online
      * 
      * @throws Exception
      */
     @Test
-    public void jobMustRunOnAllRequestedSlaves_including_Master_IgnoreOfflineNodes() throws Exception {
+    public void jobMustRunOnAllRequestedSlaves_including_Controller_IgnoreOfflineNodes() throws Exception {
 
-        final List<String> defaultNodeNames = Arrays.asList("master", onlineNode1.getNodeName(), offlineNode.getNodeName(), onlineNode2.getNodeName());
+        final List<String> defaultNodeNames = Arrays.asList(controllerLabel, onlineNode1.getNodeName(), offlineNode.getNodeName(), onlineNode2.getNodeName());
         runTest(3, 0, false, new NodeParameterDefinition("NODE", "desc", defaultNodeNames, Collections.singletonList(Constants.ALL_NODES), Constants.ALL_CASES, true));
 
     }
@@ -157,8 +159,8 @@ public class TriggerJobsTest {
     public void testTriggerViaCurlWithValue() throws Exception {
         FreeStyleProject projectA = j.createFreeStyleProject("projectA");
         NodeParameterDefinition parameterDefinition = new NodeParameterDefinition(
-                "NODE", "desc", Collections.singletonList("master"), Collections.singletonList(onlineNode1.getNodeName()), (String) null, new AllNodeEligibility());
-        String json = "{\"parameter\":[{\"name\":\"NODE\",\"value\":[\"master\"]}]}";
+                "NODE", "desc", Collections.singletonList(controllerLabel), Collections.singletonList(onlineNode1.getNodeName()), (String) null, new AllNodeEligibility());
+        String json = "{\"parameter\":[{\"name\":\"NODE\",\"value\":[\"" + controllerLabel + "\"]}]}";
         runTestViaCurl(projectA, parameterDefinition, json, 1, Result.SUCCESS);
     }
 
@@ -172,8 +174,8 @@ public class TriggerJobsTest {
     public void testTriggerViaCurlWithLabel() throws Exception {
         FreeStyleProject projectA = j.createFreeStyleProject("projectA");
         NodeParameterDefinition parameterDefinition = new NodeParameterDefinition(
-                "NODE", "desc", Collections.singletonList("master"), Collections.singletonList(onlineNode1.getNodeName()), (String) null, new AllNodeEligibility());
-        String json = "{\"parameter\":[{\"name\":\"NODE\",\"label\":[\"master\"]}]}";
+                "NODE", "desc", Collections.singletonList(controllerLabel), Collections.singletonList(onlineNode1.getNodeName()), (String) null, new AllNodeEligibility());
+        String json = "{\"parameter\":[{\"name\":\"NODE\",\"label\":[\"" + controllerLabel + "\"]}]}";
         runTestViaCurl(projectA, parameterDefinition, json, 1, Result.SUCCESS);
     }
 
@@ -187,8 +189,8 @@ public class TriggerJobsTest {
     public void testTriggerViaCurlWithLabels() throws Exception {
         FreeStyleProject projectA = j.createFreeStyleProject("projectA");
         NodeParameterDefinition parameterDefinition = new NodeParameterDefinition(
-                "NODE", "desc", Collections.singletonList("master"), Collections.singletonList(onlineNode1.getNodeName()), (String) null, new AllNodeEligibility());
-        String json = "{\"parameter\":[{\"name\":\"NODE\",\"labels\":[\"master\"]}]}";
+                "NODE", "desc", Collections.singletonList(controllerLabel), Collections.singletonList(onlineNode1.getNodeName()), (String) null, new AllNodeEligibility());
+        String json = "{\"parameter\":[{\"name\":\"NODE\",\"labels\":[\"" + controllerLabel + "\"]}]}";
         runTestViaCurl(projectA, parameterDefinition, json, 1, Result.SUCCESS);
     }
 

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesForLabelBuildParameterFactoryTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesForLabelBuildParameterFactoryTest.java
@@ -82,7 +82,11 @@ public class AllNodesForLabelBuildParameterFactoryTest extends HudsonTestCase {
         projectA.scheduleBuild2(0);
 
         // Wait for Project to be in Queue
-        Thread.sleep(1000);
+        // Sleep up to 1 second
+        int counter = 0;
+        do {
+            Thread.sleep(103); // give time to finish (0.1 second)
+        } while (++counter < 10 && hudson.getQueue().getItem(projectB) == null);
 
         Queue.Item projectBInQueue = hudson.getQueue().getItem(projectB);
 

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesForLabelBuildParameterFactoryTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesForLabelBuildParameterFactoryTest.java
@@ -22,61 +22,70 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 /**
  * @author wolfs
  */
-public class AllNodesForLabelBuildParameterFactoryTest extends HudsonTestCase {
+public class AllNodesForLabelBuildParameterFactoryTest {
 
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
     public void testLabelFactoryNonBlocking() throws Exception {
-		// create a slave with a given label to execute projectB on
+        // create a slave with a given label to execute projectB on
         String label = "label";
         List<DumbSlave> slaves = createSlaves(label,3);
 
-        FreeStyleProject projectB = createFreeStyleProject();
+        FreeStyleProject projectB = j.createFreeStyleProject();
         projectB.setQuietPeriod(1);
 
-		// create projectA, which triggers projectB with a given label parameter
-		Project<?, ?> projectA = createFreeStyleProject();
+        // create projectA, which triggers projectB with a given label parameter
+        Project<?, ?> projectA = j.createFreeStyleProject();
         addLabelParameterFactory(projectA, projectB, label);
 
         projectA.scheduleBuild2(0);
 
-        waitUntilNoActivity();
+        j.waitUntilNoActivity();
 
         assertBuiltOnEachSlave(projectB, slaves);
-
-        teardownSlaves(slaves);
     }
 
+    @Test
     public void testLabelFactoryBlocking() throws Exception {
-		// create a slave with a given label to execute projectB on
+        // create a slave with a given label to execute projectB on
         String label = "label";
         List<DumbSlave> slaves = createSlaves(label,2);
 
-        FreeStyleProject projectB = createFreeStyleProject();
+        FreeStyleProject projectB = j.createFreeStyleProject();
         projectB.setQuietPeriod(1);
 
-		// create projectA, which triggers projectB with a given label parameter
-		Project<?, ?> projectA = createFreeStyleProject();
+        // create projectA, which triggers projectB with a given label parameter
+        Project<?, ?> projectA = j.createFreeStyleProject();
         addBlockingLabelParameterFactory(projectA, projectB, label);
 
         projectA.scheduleBuild2(0);
 
-        waitUntilNoActivity();
+        j.waitUntilNoActivity();
 
         assertBuiltOnEachSlave(projectB, slaves);
-
-        teardownSlaves(slaves);
     }
 
+    @Test
     public void testNoSlavesWithLabel() throws Exception {
-        Project<?, ?> projectA = createFreeStyleProject();
-        FreeStyleProject projectB = createFreeStyleProject();
+        Project<?, ?> projectA = j.createFreeStyleProject();
+        FreeStyleProject projectB = j.createFreeStyleProject();
         projectB.setQuietPeriod(0);
 
         String label = "label";
@@ -89,20 +98,13 @@ public class AllNodesForLabelBuildParameterFactoryTest extends HudsonTestCase {
         int counter = 0;
         do {
             Thread.sleep(103); // give time to finish (0.1 second)
-        } while (++counter < 10 && hudson.getQueue().getItem(projectB) == null);
+        } while (++counter < 10 && j.jenkins.getQueue().getItem(projectB) == null);
 
-        Queue.Item projectBInQueue = hudson.getQueue().getItem(projectB);
+        Queue.Item projectBInQueue = j.jenkins.getQueue().getItem(projectB);
 
         assertNotNull(projectBInQueue);
         assertEquals(label, projectBInQueue.getAssignedLabel().getName());
         assertThat("Full sleep time consumed", counter, is(lessThan(10)));
-
-    }
-
-    private void teardownSlaves(List<DumbSlave> slaves) throws IOException {
-        for (DumbSlave slave : slaves) {
-            hudson.removeNode(slave);
-        }
     }
 
     private void assertBuiltOnEachSlave(FreeStyleProject projectB, List<DumbSlave> slaves) {
@@ -142,9 +144,9 @@ public class AllNodesForLabelBuildParameterFactoryTest extends HudsonTestCase {
     }
 
     private List<DumbSlave> createSlaves(String label, int num) throws Exception {
-        List<DumbSlave> slaves = new ArrayList<DumbSlave>();
+        List<DumbSlave> slaves = new ArrayList<DumbSlave>(num);
         for (int i = 0; i < num; i++) {
-            DumbSlave slave = createOnlineSlave(new LabelAtom(label));
+            DumbSlave slave = j.createSlave(new LabelAtom(label));
             slave.setMode(Node.Mode.EXCLUSIVE);
             slaves.add(slave);
         }

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesForLabelBuildParameterFactoryTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesForLabelBuildParameterFactoryTest.java
@@ -24,6 +24,9 @@ import java.util.Set;
 
 import org.jvnet.hudson.test.HudsonTestCase;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
 /**
  * @author wolfs
  */
@@ -92,7 +95,7 @@ public class AllNodesForLabelBuildParameterFactoryTest extends HudsonTestCase {
 
         assertNotNull(projectBInQueue);
         assertEquals(label, projectBInQueue.getAssignedLabel().getName());
-
+        assertThat("Full sleep time consumed", counter, is(lessThan(10)));
 
     }
 


### PR DESCRIPTION
## [JENKINS-66511](https://issues.jenkins.io/browse/JENKINS-66511) Support inclusive naming

Fresh installations of Jenkins 2.309 and later use the label 'built-in' for the node that is available from the controller.  Adapt the plugin and its tests to work with both the original naming of the controller node and the more inclusive new naming of the controller node.

* Allow parallel tests
* Fix assertion spelling error, reduce runtime
* [JENKINS-66511] Adapt test for inclusive naming
* [JENKINS-66511] Inclusive naming fix for TriggerJobsTest
* [JENKINS-66511] Adapt parameter definition for inclusive naming
* [JENKINS-66511] Use controller label instead of 'master'
