### PR TITLE
[JENKINS-66891] Check querySelector is not null before reading value

### DIFF
--- a/src/main/webapp/lib/nodelabel.js
+++ b/src/main/webapp/lib/nodelabel.js
@@ -43,13 +43,10 @@
 		});
 
 		function checkConcurrentExecutionValuesNode() {
-			if (matches(concurrentBuild, ":checked") &&
-                            (document.querySelector('input[type="radio"][name$=triggerIfResult]:checked') != null &&
-                             document.querySelector('input[type="radio"][name$=triggerIfResult]:checked').value != "allowMultiSelectionForConcurrentBuilds")) {
+			var radioButton = document.querySelector('input[type="radio"][name$=triggerIfResult]:checked');
+			if (matches(concurrentBuild, ":checked") && radioButton && radioButton.value != "allowMultiSelectionForConcurrentBuilds") {
 				show(document.querySelector("#allowmultinodeselection"));
-			} else if (!matches(concurrentBuild, ":checked") &&
-                                   (document.querySelector('input[type="radio"][name$=triggerIfResult]:checked') != null &&
-                                    document.querySelector('input[type="radio"][name$=triggerIfResult]:checked').value == "allowMultiSelectionForConcurrentBuilds")) {
+			} else if (!matches(concurrentBuild, ":checked") && radioButton && radioButton.value == "allowMultiSelectionForConcurrentBuilds") {
 				show(document.querySelector("#allowmultinodeselection"));
 			} else {
 				hide(document.querySelector("#allowmultinodeselection"));

--- a/src/main/webapp/lib/nodelabel.js
+++ b/src/main/webapp/lib/nodelabel.js
@@ -43,9 +43,13 @@
 		});
 
 		function checkConcurrentExecutionValuesNode() {
-			if (matches(concurrentBuild, ":checked") && (document.querySelector('input[type="radio"][name$=triggerIfResult]:checked').value != "allowMultiSelectionForConcurrentBuilds")) {
+			if (matches(concurrentBuild, ":checked") &&
+                            (document.querySelector('input[type="radio"][name$=triggerIfResult]:checked') != null &&
+                             document.querySelector('input[type="radio"][name$=triggerIfResult]:checked').value != "allowMultiSelectionForConcurrentBuilds")) {
 				show(document.querySelector("#allowmultinodeselection"));
-			} else if (!matches(concurrentBuild, ":checked") && (document.querySelector('input[type="radio"][name$=triggerIfResult]:checked').value == "allowMultiSelectionForConcurrentBuilds")) {
+			} else if (!matches(concurrentBuild, ":checked") &&
+                                   (document.querySelector('input[type="radio"][name$=triggerIfResult]:checked') != null &&
+                                    document.querySelector('input[type="radio"][name$=triggerIfResult]:checked').value == "allowMultiSelectionForConcurrentBuilds")) {
 				show(document.querySelector("#allowmultinodeselection"));
 			} else {
 				hide(document.querySelector("#allowmultinodeselection"));


### PR DESCRIPTION
## [JENKINS-66891](https://issues.jenkins.io/browse/JENKINS-66891) Fix ATH null querySelector report

The ATH is failing (relatively reliably in CI, but not locally) presumably due to a timing issue.

Failure is due to:

```
JavaScript error:
  http://127.0.0.1:65293/static/659022bd/plugin/nodelabelparameter/lib/nodelabel.js,
    line 48: TypeError: document.querySelector(...) is null
```

https://github.com/jenkinsci/nodelabelparameter-plugin/blob/5c9da6313133f254b9ce3eb60712afd3294bd6ca/src/main/webapp/lib/nodelabel.js#L48

it may be that the page is being unloaded immediately after being loaded, or that the ready condition is not correct.

This change is more defensive and checks the element is not null before checking a property of it.

I've checked interactively with the Chrome debugger and I'm able to reach the modified line that shows the change.  The new check for null does not seem to harm anything in my interactive testing.

Would appreciate a review from @halkeye or @jtnord.  I am "out of my depth" when using JavaScript and would appreciate any insights or education on the mistakes I've made in these JavaScript changes (or any other JavaScript changes).