### PR TITLE
Prevent unused Java imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,32 @@
 	</dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>2.17.7</version>
+          <configuration>
+            <!-- define a language-specific format -->
+            <java>
+              <!-- no need to specify files, inferred automatically -->
+              <endWithNewline></endWithNewline>
+              <removeUnusedImports></removeUnusedImports>
+            </java>
+          </configuration>
+          <executions>
+            <execution>
+              <!-- Runs in verify phase by default -->
+              <goals>
+                <!-- Can be disabled using -Dspotless.check.skip -->
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
## Prevent unused Java imports

Better to prevent them in the future than rely on code review to detect them.
