### PR TITLE
POM fixups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,26 +56,20 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>javax.annotation</groupId>
-			<artifactId>javax.annotation-api</artifactId>
-                        <version>1.3.2</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>parameterized-trigger</artifactId>
-                        <version>2.36</version>
+			<version>2.36</version>
 			<optional>true</optional>
+			<exclusions>
+				<exclusion>
+					<groupId>javax.annotation</groupId>
+					<artifactId>javax.annotation-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>token-macro</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.jenkins-ci.main</groupId>
-			<artifactId>jenkins-test-harness-tools</artifactId>
-                        <version>2.2</version>
-			<scope>test</scope>
 		</dependency>
         <dependency>
             <groupId>org.assertj</groupId>


### PR DESCRIPTION
It's not good to declare an explicit dependency on a library provided by core. Better just to get it from the core baseline. `plugin-util-api` fails to do this, causing problems for downstream consumers like this plugin. Work around that by excluding the problematic trail via its top-level direct dependency (`parameterized-trigger`). As a bonus I also removed the unused `jenkins-test-harness-tools`.