### PR TITLE
Add SortPom to build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,83 +1,109 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-	<modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.jenkins-ci.plugins</groupId>
-		<artifactId>plugin</artifactId>
-                <version>4.32</version>
-                <relativePath />
-	</parent>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>4.32</version>
+    <relativePath />
+  </parent>
 
-	<artifactId>nodelabelparameter</artifactId>
-	<version>${revision}${changelist}</version>
+  <artifactId>nodelabelparameter</artifactId>
+  <version>${revision}${changelist}</version>
 
-	<packaging>hpi</packaging>
+  <packaging>hpi</packaging>
 
-	<name>Node and Label parameter plugin</name>
-	<description>The node and label parameter plugin allows to dynamically select the node on which a job should be executed.</description>
+  <name>Node and Label parameter plugin</name>
+  <description>The node and label parameter plugin allows to dynamically select the node on which a job should be executed.</description>
 
-	<url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-	<scm>
-		<connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
-		<developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-		<url>https://github.com/${gitHubRepo}</url>
-	  <tag>${scmTag}</tag>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://opensource.org/licenses/MIT</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>imod</id>
+      <name>Dominik Bartholdi</name>
+      <email />
+    </developer>
+    <developer>
+      <id>MarkEWaite</id>
+      <name>Mark Waite</name>
+      <email>mark.earl.waite@gmail.com</email>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
   </scm>
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-                <revision>1.10.4</revision>
-                <changelist>-SNAPSHOT</changelist>
-                <jenkins.version>2.289.1</jenkins.version>
-                <java.level>8</java.level>
-                <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-	</properties>
-	<developers>
-		<developer>
-			<id>imod</id>
-			<name>Dominik Bartholdi</name>
-			<email />
-		</developer>
-                <developer>
-                        <id>MarkEWaite</id>
-                        <name>Mark Waite</name>
-                        <email>mark.earl.waite@gmail.com</email>
-                </developer>
-	</developers>
-	<licenses>
-    		<license>
-                        <name>MIT License</name>
-                        <url>https://opensource.org/licenses/MIT</url>
-      			<distribution>repo</distribution>
-    		</license>
-  	</licenses>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+    <revision>1.10.4</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <jenkins.version>2.289.1</jenkins.version>
+    <java.level>8</java.level>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+  </properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.jenkins-ci.plugins</groupId>
-			<artifactId>parameterized-trigger</artifactId>
-			<version>2.36</version>
-			<optional>true</optional>
-			<exclusions>
-				<exclusion>
-					<groupId>javax.annotation</groupId>
-					<artifactId>javax.annotation-api</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.jenkins-ci.plugins</groupId>
-			<artifactId>token-macro</artifactId>
-		</dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>3.21.0</version>
-            <scope>test</scope>
-        </dependency>
-	</dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.289.x</artifactId>
+        <version>1008.vb9e22885c9cf</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>parameterized-trigger</artifactId>
+      <version>2.36</version>
+      <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>token-macro</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.21.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <build>
     <pluginManagement>
@@ -93,6 +119,14 @@
               <endWithNewline />
               <removeUnusedImports />
             </java>
+            <pom>
+              <sortPom>
+                <encoding>${project.build.sourceEncoding}</encoding>
+                <lineSeparator>\n</lineSeparator>
+                <expandEmptyElements>false</expandEmptyElements>
+                <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
+              </sortPom>
+            </pom>
           </configuration>
           <executions>
             <execution>
@@ -116,30 +150,4 @@
       </plugin>
     </plugins>
   </build>
-
-	<repositories>
-		<repository>
-			<id>repo.jenkins-ci.org</id>
-			<url>https://repo.jenkins-ci.org/public/</url>
-		</repository>
-	</repositories>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>repo.jenkins-ci.org</id>
-			<url>https://repo.jenkins-ci.org/public/</url>
-		</pluginRepository>
-	</pluginRepositories>
-
-        <dependencyManagement>
-                <dependencies>
-                        <dependency>
-                                <groupId>io.jenkins.tools.bom</groupId>
-                                <artifactId>bom-2.289.x</artifactId>
-                                <version>1008.vb9e22885c9cf</version>
-                                <type>pom</type>
-                                <scope>import</scope>
-                        </dependency>
-                </dependencies>
-        </dependencyManagement>
 </project>


### PR DESCRIPTION
Adds [SortPom](https://github.com/Ekryd/sortpom) to our Spotless configuration to automatically keep our POM files consistently indented and sorted according to the [POM Code Convention](https://maven.apache.org/developers/conventions/code.html#pom-code-convention) that was [voted on by Maven developers in 2008](https://lists.apache.org/thread/h8px5t6f3q59cnkzpj1t02wsoynr3ygk).

I suggest reviewing this change with "Hide whitespace" enabled in the GitHub UI.