### PR TITLE
Require Jenkins 2.303.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <revision>1.10.4</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.289.1</jenkins.version>
+    <jenkins.version>2.303.3</jenkins.version>
     <java.level>8</java.level>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
@@ -58,7 +58,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.289.x</artifactId>
+        <artifactId>bom-2.303.x</artifactId>
         <version>1135.va_4eeca_ea_21c1</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
## Require Jenkins 2.303.3

Jenkins 2.303.x is one of the Jenkins versions recommended by the developer guide.  Using 2.303.3 allows the plugin to continue updating to most recent plugin BOM versions.
