### PR TITLE
Run JDK 11 and 8 in ci

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,7 @@
 #!/usr/bin/env groovy
 
-buildPlugin(failFast: false)
+buildPlugin(failFast: false,
+            configurations: [
+                [platform: 'linux', jdk: '11'],
+                [platform: 'windows', jdk: '8'],
+            ])


### PR DESCRIPTION
## Run JDK 11 and JDK 8 in ci

Eventually we'll be dropping support for Java 8.  Compile and test with Java 11 and Java 8.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
