### PR TITLE
Test Java 17 in addition to Java 11 and Java 8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@
 
 buildPlugin(failFast: false,
             configurations: [
-                [platform: 'linux', jdk: '11'],
+                [platform: 'linux',   jdk: '11', jenkins: '2.342'],
+                [platform: 'linux',   jdk: '11'],
                 [platform: 'windows', jdk: '8'],
             ])

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesForLabelBuildParameterFactory.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesForLabelBuildParameterFactory.java
@@ -3,6 +3,7 @@ package org.jvnet.jenkins.plugins.nodelabelparameter.parameterizedtrigger;
 import hudson.Extension;
 import hudson.model.TaskListener;
 import hudson.model.AbstractBuild;
+import hudson.model.Label;
 import hudson.model.Node;
 import hudson.plugins.parameterizedtrigger.AbstractBuildParameterFactory;
 import hudson.plugins.parameterizedtrigger.AbstractBuildParameterFactoryDescriptor;
@@ -54,7 +55,8 @@ public class AllNodesForLabelBuildParameterFactory extends AbstractBuildParamete
         }
         
         listener.getLogger().println("Getting all nodes with label: " + labelExpanded);
-        Set<Node> nodes = Jenkins.get().getLabel(labelExpanded).getNodes();
+        Label expanded = Jenkins.get().getLabel(labelExpanded);
+        Set<Node> nodes = expanded != null ? expanded.getNodes() : null;
 
         List<AbstractBuildParameters> params = new ArrayList<>();
 


### PR DESCRIPTION
## Test with Java 17 in addition to Java 11 and Java 8

Combines #107, #108, and #110, then adds Java 17.

- Use parent pom 4.39
- Require Jenkins 2.319.3 or newer
- Bump spotless-maven-plugin from 2.21.0 to 2.22.0
- Use latest 2.319.x bom
- Use parent pom 4.40
- Remove java.level property
- Replace wiki references with plugins.jenkins.io
- Null pointer guard getLabel()
- Test with Java 17 in addition to Java 11 and Java 8

## Checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
