### PR TITLE
javadoc: Builds are triggered on agents

### DIFF
--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesBuildParameterFactory.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesBuildParameterFactory.java
@@ -19,7 +19,7 @@ import org.jvnet.jenkins.plugins.nodelabelparameter.Messages;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
- * Triggers builds on all slaves.
+ * Triggers builds on all agents.
  *
  * @author Kohsuke Kawaguchi
  */


### PR DESCRIPTION
## More inclusive namiing in Javadoc

Builds are triggered on agents.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
