### PR TITLE
[JENKINS-66175 - Show nodes when the button is clicked

### DIFF
--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinition.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinition.java
@@ -159,7 +159,7 @@ public class LabelParameterDefinition extends SimpleParameterDefinition implemen
          * @return if ok, a list of nodes matching the given label
          * @throws ServletException on error
          */
-        public FormValidation doListNodesForLabel(@QueryParameter("label") final String label) throws ServletException {
+        public FormValidation doListNodesForLabel(@QueryParameter("value") final String label) throws ServletException {
 
             if (StringUtils.isBlank(label))
                 return FormValidation.error(Messages.LabelParameterDefinition_labelRequired());

--- a/src/main/resources/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinition/index.jelly
+++ b/src/main/resources/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinition/index.jelly
@@ -36,5 +36,5 @@ THE SOFTWARE.
 		</div>
 	</f:entry>	
     <j:set var="descriptor" value="${it.descriptor}"/>
-    <f:validateButton title="${%Show nodes}" progress="${%searching...}" method="listNodesForLabel" with="label" />
+    <f:validateButton title="${%Show nodes}" progress="${%searching...}" method="listNodesForLabel" with="value" />
 </j:jelly>


### PR DESCRIPTION
## [JENKINS-66175](https://issues.jenkins.io/browse/JENKINS-66175) - Show nodes when the button is clicked

Fixed missing change: `label` -> `value`

Resolves issue [JENKINS-66175](https://issues.jenkins.io/browse/JENKINS-66175) and [JENKINS-68620](https://issues.jenkins.io/browse/JENKINS-68620)

The previous commit that broke the feature: https://github.com/jenkinsci/nodelabelparameter-plugin/commit/a9c89e637f2d5d9f5dc0ebbceae3fc7a1ae4e08a


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
No test, but did mvn install and tested the hpi file

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
