### PR TITLE
Require Jenkins 2.346.3 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ buildPlugin(failFast: false,
             // See https://github.com/jenkins-infra/helpdesk/issues/2752 for more details and updates.
             artifactCachingProxyEnabled: true,
             configurations: [
-                [platform: 'linux',   jdk: '11', jenkins: '2.342'],
-                [platform: 'linux',   jdk: '11'],
+                [platform: 'linux',   jdk: '11', jenkins: '2.376'],
+                [platform: 'linux',   jdk: '11', jenkins: '2.361.3'],
                 [platform: 'windows', jdk: '8'],
             ])

--- a/pom.xml
+++ b/pom.xml
@@ -131,14 +131,20 @@
         </plugin>
       </plugins>
     </pluginManagement>
-    <plugins>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <forkCount>1C</forkCount>
-          <reuseForks>true</reuseForks>
-        </configuration>
-      </plugin>
-    </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>continuous-integration</id>
+      <activation>
+        <property>
+          <name>env.CI</name>
+        </property>
+      </activation>
+      <properties>
+        <!-- Fork a JVM per core for automated tests on continuous integration servers -->
+        <forkCount>1C</forkCount>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <revision>1.11.1</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.319.3</jenkins.version>
+    <jenkins.version>2.346.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
@@ -55,8 +55,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.319.x</artifactId>
-        <version>1654.vcb_69d035fa_20</version>
+        <artifactId>bom-2.346.x</artifactId>
+        <version>1670.v7f165fc7a_079</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Require Jenkins 2.346.3 or newer

87% of installations of the most recent release are running Jenkins 2.346.1 or newer. Not leaving many behind by requiring at least Jenkins 2.346.3

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
