### PR TITLE
Check monthly for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,20 @@
 # Per https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
-- package-ecosystem: maven
+- package-ecosystem: "maven"
   directory: "/"
   schedule:
-    interval: weekly
+    interval: "monthly"
   open-pull-requests-limit: 10
-  target-branch: master
   reviewers:
-  - MarkEWaite
+  - markewaite
+  labels:
+  - skip-changelog
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "monthly"
+  reviewers:
+  - markewaite
   labels:
   - skip-changelog


### PR DESCRIPTION
Plugin releases are infrequent. No reason to update dependencies more
than once a month.
