### PR TITLE
Bump parameterized trigger plugin to 2.44

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>parameterized-trigger</artifactId>
-      <version>2.36</version>
+      <version>2.44</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Bump parameterized trigger plugin to 2.44

https://github.com/jenkinsci/parameterized-trigger-plugin/releases/tag/parameterized-trigger-2.44 was released in July 2022 and includes the security fixes from the 2.43.1 release.  No significant regressions reported since that release. This removes a GitHub warning and will help users that have not upgraded to have one less security vulnerability.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
