### PR TITLE
Use Palantir format instead of Google Java Format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,12 +107,8 @@
             <!-- define a language-specific format -->
             <java>
               <!-- no need to specify files, inferred automatically -->
-              <!-- apply a specific flavor of google-java-format -->
-              <googleJavaFormat>
-                <version>1.15.0</version>
-                <style>AOSP</style>
-              </googleJavaFormat>
               <endWithNewline />
+              <palantirJavaFormat />
               <removeUnusedImports />
             </java>
             <pom>

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/Constants.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/Constants.java
@@ -6,8 +6,7 @@ public class Constants {
     public static final String CASE_SUCCESS = "success";
     public static final String CASE_UNSTABLE = "unstable";
     public static final String CASE_MULTISELECT_DISALLOWED = "multiSelectionDisallowed";
-    public static final String CASE_MULTISELECT_CONCURRENT_BUILDS =
-            "allowMultiSelectionForConcurrentBuilds";
+    public static final String CASE_MULTISELECT_CONCURRENT_BUILDS = "allowMultiSelectionForConcurrentBuilds";
     public static final String MASTER = "master";
     public static final String ALL_NODES = "ALL (no restriction)";
 

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinition.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinition.java
@@ -42,7 +42,10 @@ public class LabelParameterDefinition extends SimpleParameterDefinition
 
     public final String defaultValue;
     private boolean allNodesMatchingLabel;
-    @Deprecated private transient boolean ignoreOfflineNodes;
+
+    @Deprecated
+    private transient boolean ignoreOfflineNodes;
+
     private String triggerIfResult;
 
     private NodeEligibility nodeEligibility;
@@ -59,8 +62,7 @@ public class LabelParameterDefinition extends SimpleParameterDefinition
         this.defaultValue = defaultValue;
         this.allNodesMatchingLabel = allNodesMatchingLabel;
         this.nodeEligibility = nodeEligibility == null ? new AllNodeEligibility() : nodeEligibility;
-        this.triggerIfResult =
-                StringUtils.isBlank(triggerIfResult) ? Constants.ALL_CASES : triggerIfResult;
+        this.triggerIfResult = StringUtils.isBlank(triggerIfResult) ? Constants.ALL_CASES : triggerIfResult;
     }
 
     @Deprecated
@@ -79,8 +81,7 @@ public class LabelParameterDefinition extends SimpleParameterDefinition
         } else {
             this.nodeEligibility = new AllNodeEligibility();
         }
-        this.triggerIfResult =
-                StringUtils.isBlank(triggerIfResult) ? Constants.ALL_CASES : triggerIfResult;
+        this.triggerIfResult = StringUtils.isBlank(triggerIfResult) ? Constants.ALL_CASES : triggerIfResult;
     }
 
     @Deprecated
@@ -106,8 +107,7 @@ public class LabelParameterDefinition extends SimpleParameterDefinition
 
     @Override
     public LabelParameterValue getDefaultParameterValue() {
-        return new LabelParameterValue(
-                getName(), defaultValue, allNodesMatchingLabel, nodeEligibility);
+        return new LabelParameterValue(getName(), defaultValue, allNodesMatchingLabel, nodeEligibility);
     }
 
     public boolean isAllNodesMatchingLabel() {
@@ -158,13 +158,11 @@ public class LabelParameterDefinition extends SimpleParameterDefinition
             try {
                 int matchingNodeCount = getNodesForLabel(value).size(); // validates expression
                 return matchingNodeCount == 0
-                        ? FormValidation.warning(
-                                Messages.NodeLabelParameterDefinition_noNodeMatched(value))
+                        ? FormValidation.warning(Messages.NodeLabelParameterDefinition_noNodeMatched(value))
                         : FormValidation.ok();
             } catch (ANTLRException e) {
                 return FormValidation.error(
-                        Messages.NodeLabelParameterDefinition_labelExpressionNotValid(
-                                value, e.getMessage()));
+                        Messages.NodeLabelParameterDefinition_labelExpressionNotValid(value, e.getMessage()));
             }
         }
 
@@ -175,30 +173,26 @@ public class LabelParameterDefinition extends SimpleParameterDefinition
          * @return if ok, a list of nodes matching the given label
          * @throws ServletException on error
          */
-        public FormValidation doListNodesForLabel(@QueryParameter("value") final String label)
-                throws ServletException {
+        public FormValidation doListNodesForLabel(@QueryParameter("value") final String label) throws ServletException {
 
             if (StringUtils.isBlank(label))
                 return FormValidation.error(Messages.LabelParameterDefinition_labelRequired());
             try {
                 final Set<Node> nodes = getNodesForLabel(label);
                 if (nodes.isEmpty()) {
-                    return FormValidation.warning(
-                            Messages.NodeLabelParameterDefinition_noNodeMatched(label));
+                    return FormValidation.warning(Messages.NodeLabelParameterDefinition_noNodeMatched(label));
                 }
                 final List<String> nodeNames =
                         nodes.stream().map(new NodeDescFunction()).collect(Collectors.toList());
                 final String html = String.join("</li><li>", nodeNames);
-                return FormValidation.okWithMarkup(
-                        "<b>"
-                                + Messages.LabelParameterDefinition_matchingNodes()
-                                + "</b><ul><li>"
-                                + html
-                                + "</li></ul>");
+                return FormValidation.okWithMarkup("<b>"
+                        + Messages.LabelParameterDefinition_matchingNodes()
+                        + "</b><ul><li>"
+                        + html
+                        + "</li></ul>");
             } catch (ANTLRException e) {
                 return FormValidation.error(
-                        Messages.NodeLabelParameterDefinition_labelExpressionNotValid(
-                                label, e.getMessage()));
+                        Messages.NodeLabelParameterDefinition_labelExpressionNotValid(label, e.getMessage()));
             }
         }
 
@@ -216,9 +210,7 @@ public class LabelParameterDefinition extends SimpleParameterDefinition
         private static final class NodeDescFunction implements Function<Node, String> {
             public String apply(Node n) {
                 String controllerLabel = Jenkins.get().getSelfLabel().getName();
-                return n != null && StringUtils.isNotBlank(n.getNodeName())
-                        ? n.getNodeName()
-                        : controllerLabel;
+                return n != null && StringUtils.isNotBlank(n.getNodeName()) ? n.getNodeName() : controllerLabel;
             }
         }
     }
@@ -251,8 +243,7 @@ public class LabelParameterDefinition extends SimpleParameterDefinition
         return Constants.ALL_CASES.equals(triggerIfResult);
     }
 
-    public void validateBuild(
-            AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
+    public void validateBuild(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
         if (build.getProject().isConcurrentBuild() && !this.isTriggerConcurrentBuilds()) {
             final String msg = Messages.BuildWrapper_param_not_concurrent(this.getName());
             throw new IllegalStateException(msg);

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterValue.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterValue.java
@@ -65,10 +65,7 @@ public class LabelParameterValue extends ParameterValue {
      */
     @DataBoundConstructor
     public LabelParameterValue(
-            String name,
-            String label,
-            boolean allNodesMatchingLabel,
-            NodeEligibility nodeEligibility) {
+            String name, String label, boolean allNodesMatchingLabel, NodeEligibility nodeEligibility) {
         super(nameOrDefault(name));
         if (label != null) {
             this.label = label.trim();
@@ -77,8 +74,7 @@ public class LabelParameterValue extends ParameterValue {
         computeNextLabels(allNodesMatchingLabel, nodeEligibility);
     }
 
-    /* package */ void computeNextLabels(
-            boolean allNodesMatchingLabel, NodeEligibility nodeEligibility) {
+    /* package */ void computeNextLabels(boolean allNodesMatchingLabel, NodeEligibility nodeEligibility) {
         if (allNodesMatchingLabel && label != null) {
             List<String> labels = getNodeNamesForLabelExpression(label);
             if (labels.isEmpty()) {
@@ -121,9 +117,7 @@ public class LabelParameterValue extends ParameterValue {
         if (StringUtils.isBlank(getLabel())) {
             // these artificial label will cause the job to stay in the queue and the user will see
             // this label
-            setLabel(
-                    Messages.LabelParameterValue_triggerWithoutValidOnlineNode(
-                            StringUtils.join(labels, ',')));
+            setLabel(Messages.LabelParameterValue_triggerWithoutValidOnlineNode(StringUtils.join(labels, ',')));
         }
     }
 
@@ -219,12 +213,10 @@ public class LabelParameterValue extends ParameterValue {
         final ParametersDefinitionProperty property =
                 build.getProject().getProperty(hudson.model.ParametersDefinitionProperty.class);
         if (property != null) {
-            final List<ParameterDefinition> parameterDefinitions =
-                    property.getParameterDefinitions();
+            final List<ParameterDefinition> parameterDefinitions = property.getParameterDefinitions();
             for (ParameterDefinition paramDef : parameterDefinitions) {
                 if (paramDef instanceof MultipleNodeDescribingParameterDefinition) {
-                    return ((MultipleNodeDescribingParameterDefinition) paramDef)
-                            .createBuildWrapper();
+                    return ((MultipleNodeDescribingParameterDefinition) paramDef).createBuildWrapper();
                 }
             }
         }
@@ -262,13 +254,9 @@ public class LabelParameterValue extends ParameterValue {
         if (c != null) {
             String cName = StringUtils.isBlank(c.getName()) ? controllerLabel : c.getName();
             build.addAction(
-                    new LabelBadgeAction(
-                            getLabel(),
-                            Messages.LabelBadgeAction_label_tooltip_node(getLabel(), cName)));
+                    new LabelBadgeAction(getLabel(), Messages.LabelBadgeAction_label_tooltip_node(getLabel(), cName)));
         } else {
-            build.addAction(
-                    new LabelBadgeAction(
-                            getLabel(), Messages.LabelBadgeAction_label_tooltip(getLabel())));
+            build.addAction(new LabelBadgeAction(getLabel(), Messages.LabelBadgeAction_label_tooltip(getLabel())));
         }
     }
 }

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NextLabelCause.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NextLabelCause.java
@@ -17,8 +17,7 @@ public class NextLabelCause extends UpstreamCause {
 
     @Override
     public String getShortDescription() {
-        return org.jvnet.jenkins.plugins.nodelabelparameter.Messages.NextLabelCause_description(
-                label);
+        return org.jvnet.jenkins.plugins.nodelabelparameter.Messages.NextLabelCause_description(label);
     }
 
     @Override

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition.java
@@ -37,11 +37,16 @@ public class NodeParameterDefinition extends SimpleParameterDefinition
 
     public final List<String> allowedSlaves;
     private List<String> defaultSlaves;
-    @Deprecated public transient String defaultValue;
+
+    @Deprecated
+    public transient String defaultValue;
+
     private String triggerIfResult;
     private boolean allowMultiNodeSelection;
     private boolean triggerConcurrentBuilds;
-    @Deprecated private boolean ignoreOfflineNodes;
+
+    @Deprecated
+    private boolean ignoreOfflineNodes;
 
     private NodeEligibility nodeEligibility;
 
@@ -90,11 +95,7 @@ public class NodeParameterDefinition extends SimpleParameterDefinition
 
     @Deprecated
     public NodeParameterDefinition(
-            String name,
-            String description,
-            String defaultValue,
-            List<String> allowedAgents,
-            String triggerIfResult) {
+            String name, String description, String defaultValue, List<String> allowedAgents, String triggerIfResult) {
         this(name, description, new ArrayList<>(), allowedAgents, triggerIfResult, false);
 
         if (this.allowedSlaves != null && this.allowedSlaves.contains(defaultValue)) {
@@ -131,9 +132,7 @@ public class NodeParameterDefinition extends SimpleParameterDefinition
      */
     public List<String> getAllowedNodesOrAll() {
         final List<String> agents =
-                allowedSlaves == null
-                                || allowedSlaves.isEmpty()
-                                || allowedSlaves.contains(Constants.ALL_NODES)
+                allowedSlaves == null || allowedSlaves.isEmpty() || allowedSlaves.contains(Constants.ALL_NODES)
                         ? getNodeNames()
                         : allowedSlaves;
 
@@ -218,8 +217,7 @@ public class NodeParameterDefinition extends SimpleParameterDefinition
         }
     }
 
-    public void validateBuild(
-            AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
+    public void validateBuild(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) {
         if (build.getProject().isConcurrentBuild() && !this.isTriggerConcurrentBuilds()) {
             final String msg = Messages.BuildWrapper_param_not_concurrent(this.getName());
             throw new IllegalStateException(msg);
@@ -254,10 +252,9 @@ public class NodeParameterDefinition extends SimpleParameterDefinition
         // as String from script: {"name":"HOSTN","value":"built-in"}
         final String name = jo.getString("name");
         // JENKINS-28374 also respect 'labels' to allow rebuilds via rebuild plugin
-        final Object joValue =
-                jo.get("value") == null
-                        ? (jo.get("labels") == null ? jo.get("label") : jo.get("labels"))
-                        : jo.get("value");
+        final Object joValue = jo.get("value") == null
+                ? (jo.get("labels") == null ? jo.get("label") : jo.get("labels"))
+                : jo.get("value");
 
         List<String> nodes = new ArrayList<>();
         if (joValue instanceof String) {

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/node/NodeEligibility.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/node/NodeEligibility.java
@@ -9,8 +9,7 @@ import hudson.model.Node;
 import java.io.Serializable;
 import jenkins.model.Jenkins;
 
-public abstract class NodeEligibility
-        implements Describable<NodeEligibility>, ExtensionPoint, Serializable {
+public abstract class NodeEligibility implements Describable<NodeEligibility>, ExtensionPoint, Serializable {
 
     public abstract boolean isEligible(Node node);
 

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesBuildParameterFactory.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesBuildParameterFactory.java
@@ -25,8 +25,7 @@ public class AllNodesBuildParameterFactory extends AbstractBuildParameterFactory
     public AllNodesBuildParameterFactory() {}
 
     @Override
-    public List<AbstractBuildParameters> getParameters(
-            AbstractBuild<?, ?> build, TaskListener listener) {
+    public List<AbstractBuildParameters> getParameters(AbstractBuild<?, ?> build, TaskListener listener) {
         Computer[] nodes = Jenkins.get().getComputers();
 
         final PrintStream logger = listener.getLogger();
@@ -35,12 +34,11 @@ public class AllNodesBuildParameterFactory extends AbstractBuildParameterFactory
             Node n = c.getNode();
             if (n != null && c.isOnline() && c.getNumExecutors() > 0) {
                 params.add(new NodeLabelBuildParameter("label", n.getSelfLabel().getName()));
-                logger.println(
-                        "trigger build on "
-                                + n.getDisplayName()
-                                + " ("
-                                + n.getSelfLabel().getName()
-                                + ")");
+                logger.println("trigger build on "
+                        + n.getDisplayName()
+                        + " ("
+                        + n.getSelfLabel().getName()
+                        + ")");
             }
         }
 

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesForLabelBuildParameterFactory.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesForLabelBuildParameterFactory.java
@@ -27,26 +27,23 @@ public class AllNodesForLabelBuildParameterFactory extends AbstractBuildParamete
     public final String nodeLabel;
     public final boolean ignoreOfflineNodes;
 
-    private static final Function<Node, String> SELF_LABEL_FUNCTION =
-            new Function<Node, String>() {
-                public String apply(Node node) {
-                    return node != null && node.getSelfLabel() != null
-                            ? node.getSelfLabel().getName()
-                            : null;
-                }
-            };
+    private static final Function<Node, String> SELF_LABEL_FUNCTION = new Function<Node, String>() {
+        public String apply(Node node) {
+            return node != null && node.getSelfLabel() != null
+                    ? node.getSelfLabel().getName()
+                    : null;
+        }
+    };
 
     @DataBoundConstructor
-    public AllNodesForLabelBuildParameterFactory(
-            String name, String nodeLabel, boolean ignoreOfflineNodes) {
+    public AllNodesForLabelBuildParameterFactory(String name, String nodeLabel, boolean ignoreOfflineNodes) {
         this.name = name;
         this.nodeLabel = nodeLabel;
         this.ignoreOfflineNodes = ignoreOfflineNodes;
     }
 
     @Override
-    public List<AbstractBuildParameters> getParameters(
-            AbstractBuild<?, ?> build, TaskListener listener)
+    public List<AbstractBuildParameters> getParameters(AbstractBuild<?, ?> build, TaskListener listener)
             throws IOException, InterruptedException, AbstractBuildParameters.DontTriggerException {
         String labelExpanded = nodeLabel;
         try {
@@ -66,8 +63,7 @@ public class AllNodesForLabelBuildParameterFactory extends AbstractBuildParamete
             listener.getLogger().println("Found no nodes");
             params.add(new NodeLabelBuildParameter(name, labelExpanded));
         } else {
-            List<String> selfLabels =
-                    nodes.stream().map(SELF_LABEL_FUNCTION).collect(Collectors.toList());
+            List<String> selfLabels = nodes.stream().map(SELF_LABEL_FUNCTION).collect(Collectors.toList());
             listener.getLogger().println("Found nodes: " + selfLabels);
             for (Node node : nodes) {
                 final String nodeSelfLabel = node.getSelfLabel().getName();
@@ -76,9 +72,7 @@ public class AllNodesForLabelBuildParameterFactory extends AbstractBuildParamete
                         params.add(new NodeLabelBuildParameter(name, nodeSelfLabel));
                     } else {
                         listener.getLogger()
-                                .println(
-                                        Messages.NodeListBuildParameterFactory_skippOfflineNode(
-                                                nodeSelfLabel));
+                                .println(Messages.NodeListBuildParameterFactory_skippOfflineNode(nodeSelfLabel));
                     }
                 } else {
                     params.add(new NodeLabelBuildParameter(name, nodeSelfLabel));
@@ -86,10 +80,7 @@ public class AllNodesForLabelBuildParameterFactory extends AbstractBuildParamete
             }
             if (params.isEmpty()) {
                 params.add(new NodeLabelBuildParameter(name, labelExpanded));
-                listener.getLogger()
-                        .println(
-                                Messages.NodeListBuildParameterFactory_noOnlineNodeFound(
-                                        labelExpanded));
+                listener.getLogger().println(Messages.NodeListBuildParameterFactory_noOnlineNodeFound(labelExpanded));
             }
         }
 

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/NodeLabelBuildParameter.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/NodeLabelBuildParameter.java
@@ -31,8 +31,7 @@ public class NodeLabelBuildParameter extends AbstractBuildParameters {
         this.nodeLabel = nodeLabel;
     }
 
-    public Action getAction(AbstractBuild<?, ?> build, TaskListener listener)
-            throws IOException, InterruptedException {
+    public Action getAction(AbstractBuild<?, ?> build, TaskListener listener) throws IOException, InterruptedException {
         String labelExpanded = nodeLabel;
         try {
             labelExpanded = TokenMacro.expandAll(build, listener, labelExpanded);

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/NodeListBuildParameterFactory.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/NodeListBuildParameterFactory.java
@@ -28,8 +28,7 @@ import org.kohsuke.stapler.QueryParameter;
 /** A build parameter factory generating NodeLabelParameters for each node matching a label */
 public class NodeListBuildParameterFactory extends AbstractBuildParameterFactory {
 
-    private static final Logger LOGGER =
-            Logger.getLogger(NodeListBuildParameterFactory.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(NodeListBuildParameterFactory.class.getName());
 
     public final String name;
     public final String nodeListString;
@@ -41,8 +40,7 @@ public class NodeListBuildParameterFactory extends AbstractBuildParameterFactory
     }
 
     @Override
-    public List<AbstractBuildParameters> getParameters(
-            AbstractBuild<?, ?> build, TaskListener listener)
+    public List<AbstractBuildParameters> getParameters(AbstractBuild<?, ?> build, TaskListener listener)
             throws IOException, InterruptedException, AbstractBuildParameters.DontTriggerException {
         String nodeListStringExpanded = nodeListString;
         try {
@@ -56,10 +54,7 @@ public class NodeListBuildParameterFactory extends AbstractBuildParameterFactory
 
         if (StringUtils.isBlank(nodeListStringExpanded)) {
             listener.getLogger()
-                    .println(
-                            "[WARN] no node name was given! ["
-                                    + nodeListString
-                                    + "], can't trigger other project");
+                    .println("[WARN] no node name was given! [" + nodeListString + "], can't trigger other project");
         } else {
 
             String[] nodes = nodeListStringExpanded.trim().split(",");
@@ -100,8 +95,7 @@ public class NodeListBuildParameterFactory extends AbstractBuildParameterFactory
         }
 
         /** Form validation method. */
-        public FormValidation doCheckNodeListString(
-                @AncestorInPath Item project, @QueryParameter String value) {
+        public FormValidation doCheckNodeListString(@AncestorInPath Item project, @QueryParameter String value) {
             if (!project.hasPermission(Item.CONFIGURE)) return FormValidation.ok();
 
             StringTokenizer tokens = new StringTokenizer(Util.fixNull(value), ",");
@@ -111,15 +105,13 @@ public class NodeListBuildParameterFactory extends AbstractBuildParameterFactory
                 if (StringUtils.isNotBlank(nodeName)) {
                     final Node node = Jenkins.get().getNode(nodeName);
                     if (node == null) {
-                        return FormValidation.error(
-                                Messages.NodeListBuildParameterFactory_nodeNotFound(nodeName));
+                        return FormValidation.error(Messages.NodeListBuildParameterFactory_nodeNotFound(nodeName));
                     }
                     hasProjects = true;
                 }
             }
             if (!hasProjects) {
-                return FormValidation.error(
-                        Messages.NodeListBuildParameterFactory_nodeNotDefined());
+                return FormValidation.error(Messages.NodeListBuildParameterFactory_nodeNotDefined());
             }
 
             return FormValidation.ok();

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/wrapper/TriggerNextBuildWrapper.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/wrapper/TriggerNextBuildWrapper.java
@@ -95,14 +95,11 @@ public class TriggerNextBuildWrapper extends BuildWrapper {
             final List<String> singleNodeList = new ArrayList<>();
             singleNodeList.add(nodeName);
             final LabelParameterValue pValue =
-                    new LabelParameterValue(
-                            parmaName, singleNodeList, parameterDefinition.getNodeEligibility());
+                    new LabelParameterValue(parmaName, singleNodeList, parameterDefinition.getNodeEligibility());
             List<ParameterValue> copies = new ArrayList<>(newPrams);
             copies.add(pValue); // where to do the next build
             listener.getLogger().println("Schedule build on node " + nodeName);
-            build.getProject()
-                    .scheduleBuild(
-                            0, new NextLabelCause(nodeName, build), new ParametersAction(copies));
+            build.getProject().scheduleBuild(0, new NextLabelCause(nodeName, build), new ParametersAction(copies));
         }
     }
 
@@ -113,8 +110,7 @@ public class TriggerNextBuildWrapper extends BuildWrapper {
     private class TriggerNextBuildEnvironment extends Environment {
 
         @Override
-        public boolean tearDown(AbstractBuild build, BuildListener listener)
-                throws IOException, InterruptedException {
+        public boolean tearDown(AbstractBuild build, BuildListener listener) throws IOException, InterruptedException {
             triggerBuilds(build, listener);
             return true;
         }
@@ -136,18 +132,13 @@ public class TriggerNextBuildWrapper extends BuildWrapper {
                     nextNodes = new ArrayList<>(nextNodes);
                     nextNodes.remove(initialBuildNode);
                     if (!nextNodes.isEmpty()
-                            && shouldScheduleNextJob(
-                                    build.getResult(), parameterDefinition.getTriggerIfResult())) {
-                        LabelParameterValue newNodeParam =
-                                new LabelParameterValue(
-                                        origNodePram.getName(),
-                                        nextNodes,
-                                        parameterDefinition.getNodeEligibility());
+                            && shouldScheduleNextJob(build.getResult(), parameterDefinition.getTriggerIfResult())) {
+                        LabelParameterValue newNodeParam = new LabelParameterValue(
+                                origNodePram.getName(), nextNodes, parameterDefinition.getNodeEligibility());
                         newPrams.add(newNodeParam);
                         final String nextLabel = newNodeParam.getLabel();
                         if (nextLabel != null) {
-                            listener.getLogger()
-                                    .print("schedule single build on node " + nextLabel);
+                            listener.getLogger().print("schedule single build on node " + nextLabel);
                             nextLabelCause = new NextLabelCause(nextLabel, build);
                             triggerNewBuild = true;
                         } else {
@@ -188,11 +179,9 @@ public class TriggerNextBuildWrapper extends BuildWrapper {
                 // result.
 
                 if (Constants.CASE_SUCCESS.equals(runIfResult)) {
-                    return ((buildResult == null)
-                            || (buildResult.isBetterOrEqualTo(Result.SUCCESS)));
+                    return ((buildResult == null) || (buildResult.isBetterOrEqualTo(Result.SUCCESS)));
                 } else if (Constants.CASE_UNSTABLE.equals(runIfResult)) {
-                    return ((buildResult == null)
-                            || (buildResult.isBetterOrEqualTo(Result.UNSTABLE)));
+                    return ((buildResult == null) || (buildResult.isBetterOrEqualTo(Result.UNSTABLE)));
                 }
             }
 

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodelLabelNodePropertyTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodelLabelNodePropertyTest.java
@@ -28,7 +28,9 @@ import org.jvnet.jenkins.plugins.nodelabelparameter.node.IgnoreOfflineNodeEligib
  */
 public class NodelLabelNodePropertyTest {
 
-    @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
     private String controllerLabel = null;
 
     private DumbSlave onlineNode1;
@@ -40,9 +42,7 @@ public class NodelLabelNodePropertyTest {
         onlineNode1 = j.createOnlineSlave(new LabelAtom("mylabel1"));
         onlineNode2 = j.createOnlineSlave(new LabelAtom("mylabel2"));
         offlineNode = j.createOnlineSlave(new LabelAtom("mylabel3"));
-        offlineNode
-                .getComputer()
-                .setTemporarilyOffline(true, new hudson.slaves.OfflineCause.ByCLI("mark offline"));
+        offlineNode.getComputer().setTemporarilyOffline(true, new hudson.slaves.OfflineCause.ByCLI("mark offline"));
         controllerLabel = j.jenkins.getSelfLabel().getName();
     }
 
@@ -67,10 +67,7 @@ public class NodelLabelNodePropertyTest {
         assertFalse(NodeUtil.isNodeOnline(offlineNode.getNodeName()));
 
         final List<String> defaultNodeNames =
-                Arrays.asList(
-                        onlineNode1.getNodeName(),
-                        offlineNode.getNodeName(),
-                        onlineNode2.getNodeName());
+                Arrays.asList(onlineNode1.getNodeName(), offlineNode.getNodeName(), onlineNode2.getNodeName());
         runTest(
                 2,
                 0,
@@ -97,12 +94,8 @@ public class NodelLabelNodePropertyTest {
         assertTrue(NodeUtil.isNodeOnline(onlineNode2.getNodeName()));
         assertFalse(NodeUtil.isNodeOnline(offlineNode.getNodeName()));
 
-        final List<String> defaultNodeNames =
-                Arrays.asList(
-                        offlineNode.getNodeName(),
-                        onlineNode2.getNodeName(),
-                        onlineNode1.getNodeName(),
-                        controllerLabel);
+        final List<String> defaultNodeNames = Arrays.asList(
+                offlineNode.getNodeName(), onlineNode2.getNodeName(), onlineNode1.getNodeName(), controllerLabel);
         runTest(
                 3,
                 1,
@@ -130,7 +123,8 @@ public class NodelLabelNodePropertyTest {
         projectA.addProperty(pdp);
 
         j.assertBuildStatus(
-                Result.SUCCESS, projectA.scheduleBuild2(0, new Cause.UserIdCause()).get());
+                Result.SUCCESS,
+                projectA.scheduleBuild2(0, new Cause.UserIdCause()).get());
         // we can't wait for no activity, as this would also wait for the jobs we expect to stay in
         // the queue
         // j.waitUntilNoActivity();
@@ -139,10 +133,7 @@ public class NodelLabelNodePropertyTest {
         do {
             Thread.sleep(1003); // give async triggered jobs some time to finish (1 second)
         } while (++counter < 10 && projectA.getLastBuild().number < expectedNumberOfExecutedRuns);
-        assertEquals(
-                "expcted number of runs",
-                expectedNumberOfExecutedRuns,
-                projectA.getLastBuild().number);
+        assertEquals("expcted number of runs", expectedNumberOfExecutedRuns, projectA.getLastBuild().number);
         assertEquals(
                 "expected number of items in the queue",
                 expectedNumberOfItemsInTheQueue,

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/TriggerJobsTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/TriggerJobsTest.java
@@ -35,7 +35,9 @@ import org.jvnet.jenkins.plugins.nodelabelparameter.node.AllNodeEligibility;
  */
 public class TriggerJobsTest {
 
-    @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
     private String controllerLabel = null;
 
     private DumbSlave onlineNode1;
@@ -47,9 +49,7 @@ public class TriggerJobsTest {
         onlineNode1 = j.createOnlineSlave(new LabelAtom("mylabel1"));
         onlineNode2 = j.createOnlineSlave(new LabelAtom("mylabel2"));
         offlineNode = j.createOnlineSlave(new LabelAtom("mylabel3"));
-        offlineNode
-                .getComputer()
-                .setTemporarilyOffline(true, new hudson.slaves.OfflineCause.ByCLI("mark offline"));
+        offlineNode.getComputer().setTemporarilyOffline(true, new hudson.slaves.OfflineCause.ByCLI("mark offline"));
         controllerLabel = j.jenkins.getSelfLabel().getName();
     }
 
@@ -70,10 +70,7 @@ public class TriggerJobsTest {
     public void jobMustRunOnAllRequestedAgents_IgnoreOfflineNodes() throws Exception {
 
         final List<String> defaultNodeNames =
-                Arrays.asList(
-                        onlineNode1.getNodeName(),
-                        offlineNode.getNodeName(),
-                        onlineNode2.getNodeName());
+                Arrays.asList(onlineNode1.getNodeName(), offlineNode.getNodeName(), onlineNode2.getNodeName());
         runTest(
                 2,
                 0,
@@ -101,10 +98,7 @@ public class TriggerJobsTest {
             return;
         }
         final List<String> defaultNodeNames =
-                Arrays.asList(
-                        onlineNode1.getNodeName(),
-                        offlineNode.getNodeName(),
-                        onlineNode2.getNodeName());
+                Arrays.asList(onlineNode1.getNodeName(), offlineNode.getNodeName(), onlineNode2.getNodeName());
         runTest(
                 2,
                 1,
@@ -125,14 +119,10 @@ public class TriggerJobsTest {
      * @throws Exception
      */
     @Test
-    public void jobMustRunOnAllRequestedAgents_Concurrent_NotIgnoringOfflineNodes()
-            throws Exception {
+    public void jobMustRunOnAllRequestedAgents_Concurrent_NotIgnoringOfflineNodes() throws Exception {
 
         final List<String> defaultNodeNames =
-                Arrays.asList(
-                        onlineNode1.getNodeName(),
-                        offlineNode.getNodeName(),
-                        onlineNode2.getNodeName());
+                Arrays.asList(onlineNode1.getNodeName(), offlineNode.getNodeName(), onlineNode2.getNodeName());
         runTest(
                 2,
                 1,
@@ -156,10 +146,7 @@ public class TriggerJobsTest {
     public void jobMustRunOnAllRequestedAgents_Concurrent_IgnoreOfflineNodes() throws Exception {
 
         final List<String> defaultNodeNames =
-                Arrays.asList(
-                        onlineNode1.getNodeName(),
-                        offlineNode.getNodeName(),
-                        onlineNode2.getNodeName());
+                Arrays.asList(onlineNode1.getNodeName(), offlineNode.getNodeName(), onlineNode2.getNodeName());
         runTest(
                 2,
                 0,
@@ -180,15 +167,10 @@ public class TriggerJobsTest {
      * @throws Exception
      */
     @Test
-    public void jobMustRunOnAllRequestedAgents_including_Node_on_Controller_IgnoreOfflineNodes()
-            throws Exception {
+    public void jobMustRunOnAllRequestedAgents_including_Node_on_Controller_IgnoreOfflineNodes() throws Exception {
 
-        final List<String> defaultNodeNames =
-                Arrays.asList(
-                        controllerLabel,
-                        onlineNode1.getNodeName(),
-                        offlineNode.getNodeName(),
-                        onlineNode2.getNodeName());
+        final List<String> defaultNodeNames = Arrays.asList(
+                controllerLabel, onlineNode1.getNodeName(), offlineNode.getNodeName(), onlineNode2.getNodeName());
         runTest(
                 3,
                 0,
@@ -220,7 +202,8 @@ public class TriggerJobsTest {
         projectA.addProperty(pdp);
 
         j.assertBuildStatus(
-                Result.SUCCESS, projectA.scheduleBuild2(0, new Cause.UserIdCause()).get());
+                Result.SUCCESS,
+                projectA.scheduleBuild2(0, new Cause.UserIdCause()).get());
         // we can't wait for no activity, as this would also wait for the jobs we expect to stay in
         // the queue
         // j.waitUntilNoActivity();
@@ -229,8 +212,7 @@ public class TriggerJobsTest {
         do {
             Thread.sleep(1003); // give async triggered jobs some time to finish (1 second)
         } while (++counter < 10 && projectA.getLastBuild().number < expectedNumberOfExecutedRuns);
-        assertEquals(
-                "Number of builds", expectedNumberOfExecutedRuns, projectA.getLastBuild().number);
+        assertEquals("Number of builds", expectedNumberOfExecutedRuns, projectA.getLastBuild().number);
         assertEquals(
                 "Pending items: " + j.jenkins.getQueue().getPendingItems(),
                 0,
@@ -251,16 +233,14 @@ public class TriggerJobsTest {
     @Test
     public void testTriggerViaCurlWithValue() throws Exception {
         FreeStyleProject projectA = j.createFreeStyleProject("projectA");
-        NodeParameterDefinition parameterDefinition =
-                new NodeParameterDefinition(
-                        "NODE",
-                        "desc",
-                        Collections.singletonList(controllerLabel),
-                        Collections.singletonList(onlineNode1.getNodeName()),
-                        null,
-                        new AllNodeEligibility());
-        String json =
-                "{\"parameter\":[{\"name\":\"NODE\",\"value\":[\"" + controllerLabel + "\"]}]}";
+        NodeParameterDefinition parameterDefinition = new NodeParameterDefinition(
+                "NODE",
+                "desc",
+                Collections.singletonList(controllerLabel),
+                Collections.singletonList(onlineNode1.getNodeName()),
+                null,
+                new AllNodeEligibility());
+        String json = "{\"parameter\":[{\"name\":\"NODE\",\"value\":[\"" + controllerLabel + "\"]}]}";
         runTestViaCurl(projectA, parameterDefinition, json, 1, Result.SUCCESS);
     }
 
@@ -273,16 +253,14 @@ public class TriggerJobsTest {
     @Test
     public void testTriggerViaCurlWithLabel() throws Exception {
         FreeStyleProject projectA = j.createFreeStyleProject("projectA");
-        NodeParameterDefinition parameterDefinition =
-                new NodeParameterDefinition(
-                        "NODE",
-                        "desc",
-                        Collections.singletonList(controllerLabel),
-                        Collections.singletonList(onlineNode1.getNodeName()),
-                        null,
-                        new AllNodeEligibility());
-        String json =
-                "{\"parameter\":[{\"name\":\"NODE\",\"label\":[\"" + controllerLabel + "\"]}]}";
+        NodeParameterDefinition parameterDefinition = new NodeParameterDefinition(
+                "NODE",
+                "desc",
+                Collections.singletonList(controllerLabel),
+                Collections.singletonList(onlineNode1.getNodeName()),
+                null,
+                new AllNodeEligibility());
+        String json = "{\"parameter\":[{\"name\":\"NODE\",\"label\":[\"" + controllerLabel + "\"]}]}";
         runTestViaCurl(projectA, parameterDefinition, json, 1, Result.SUCCESS);
     }
 
@@ -295,16 +273,14 @@ public class TriggerJobsTest {
     @Test
     public void testTriggerViaCurlWithLabels() throws Exception {
         FreeStyleProject projectA = j.createFreeStyleProject("projectA");
-        NodeParameterDefinition parameterDefinition =
-                new NodeParameterDefinition(
-                        "NODE",
-                        "desc",
-                        Collections.singletonList(controllerLabel),
-                        Collections.singletonList(onlineNode1.getNodeName()),
-                        null,
-                        new AllNodeEligibility());
-        String json =
-                "{\"parameter\":[{\"name\":\"NODE\",\"labels\":[\"" + controllerLabel + "\"]}]}";
+        NodeParameterDefinition parameterDefinition = new NodeParameterDefinition(
+                "NODE",
+                "desc",
+                Collections.singletonList(controllerLabel),
+                Collections.singletonList(onlineNode1.getNodeName()),
+                null,
+                new AllNodeEligibility());
+        String json = "{\"parameter\":[{\"name\":\"NODE\",\"labels\":[\"" + controllerLabel + "\"]}]}";
         runTestViaCurl(projectA, parameterDefinition, json, 1, Result.SUCCESS);
     }
 
@@ -323,9 +299,7 @@ public class TriggerJobsTest {
      * @throws Exception when executing requests and also while using the JenkinsRule and WebClient
      *     methods
      */
-    private <
-                    JobT extends Job<JobT, RunT> & ParameterizedJobMixIn.ParameterizedJob,
-                    RunT extends Run<JobT, RunT>>
+    private <JobT extends Job<JobT, RunT> & ParameterizedJobMixIn.ParameterizedJob, RunT extends Run<JobT, RunT>>
             void runTestViaCurl(
                     JobT project,
                     NodeParameterDefinition parameterDefinition,
@@ -344,11 +318,9 @@ public class TriggerJobsTest {
         // add security crumb (cannot modify the list after that, so we recreate the parameters
         // right away)
         wc.addCrumb(requestSettings);
-        List<com.gargoylesoftware.htmlunit.util.NameValuePair> requestParameters =
-                new ArrayList<>();
+        List<com.gargoylesoftware.htmlunit.util.NameValuePair> requestParameters = new ArrayList<>();
         requestParameters.add(new com.gargoylesoftware.htmlunit.util.NameValuePair("json", json));
-        requestParameters.add(
-                new com.gargoylesoftware.htmlunit.util.NameValuePair("Submit", "Build"));
+        requestParameters.add(new com.gargoylesoftware.htmlunit.util.NameValuePair("Submit", "Build"));
         requestParameters.addAll(requestSettings.getRequestParameters());
         requestSettings.setRequestParameters(requestParameters);
 

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesForLabelBuildParameterFactoryTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesForLabelBuildParameterFactoryTest.java
@@ -32,7 +32,8 @@ import org.jvnet.hudson.test.JenkinsRule;
  */
 public class AllNodesForLabelBuildParameterFactoryTest {
 
-    @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
     @Test
     public void testLabelFactoryNonBlocking() throws Exception {
@@ -114,35 +115,23 @@ public class AllNodesForLabelBuildParameterFactoryTest {
         }
     }
 
-    private void addLabelParameterFactory(
-            Project<?, ?> projectA, FreeStyleProject projectB, String label) {
+    private void addLabelParameterFactory(Project<?, ?> projectA, FreeStyleProject projectB, String label) {
         addLabelParameterFactory(projectA, projectB, null, label);
     }
 
-    private void addBlockingLabelParameterFactory(
-            Project<?, ?> projectA, FreeStyleProject projectB, String label) {
+    private void addBlockingLabelParameterFactory(Project<?, ?> projectA, FreeStyleProject projectB, String label) {
         addLabelParameterFactory(
-                projectA,
-                projectB,
-                new BlockingBehaviour(Result.FAILURE, Result.UNSTABLE, Result.FAILURE),
-                label);
+                projectA, projectB, new BlockingBehaviour(Result.FAILURE, Result.UNSTABLE, Result.FAILURE), label);
     }
 
     private void addLabelParameterFactory(
-            Project<?, ?> projectA,
-            FreeStyleProject projectB,
-            BlockingBehaviour blockingBehaviour,
-            String label) {
+            Project<?, ?> projectA, FreeStyleProject projectB, BlockingBehaviour blockingBehaviour, String label) {
         projectA.getBuildersList()
-                .add(
-                        new TriggerBuilder(
-                                new BlockableBuildTriggerConfig(
-                                        projectB.getName(),
-                                        blockingBehaviour,
-                                        Collections.singletonList(
-                                                new AllNodesForLabelBuildParameterFactory(
-                                                        "LABEL", label, false)),
-                                        Collections.emptyList())));
+                .add(new TriggerBuilder(new BlockableBuildTriggerConfig(
+                        projectB.getName(),
+                        blockingBehaviour,
+                        Collections.singletonList(new AllNodesForLabelBuildParameterFactory("LABEL", label, false)),
+                        Collections.emptyList())));
     }
 
     private List<DumbSlave> createSlaves(String label, int num) throws Exception {

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesForLabelBuildParameterFactoryUnitTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesForLabelBuildParameterFactoryUnitTest.java
@@ -32,7 +32,8 @@ import org.jvnet.hudson.test.TestBuilder;
 
 public class AllNodesForLabelBuildParameterFactoryUnitTest {
 
-    @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
     @Before
     public void setUp() throws Exception {
@@ -61,35 +62,29 @@ public class AllNodesForLabelBuildParameterFactoryUnitTest {
 
         final List<Boolean> executed = new ArrayList<>();
 
-        projectA.getBuildersList()
-                .add(
-                        new TestBuilder() {
-                            public boolean perform(
-                                    AbstractBuild<?, ?> build,
-                                    Launcher launcher,
-                                    BuildListener listener)
-                                    throws InterruptedException, IOException {
-                                try {
+        projectA.getBuildersList().add(new TestBuilder() {
+            public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                    throws InterruptedException, IOException {
+                try {
 
-                                    shouldGetParameterForEachMatchingNode(
-                                            twoNodesFactory, build, listener);
-                                    noMatchingNodeShouldYieldSameLabel(
-                                            dummyNodesFactory, build, listener);
+                    shouldGetParameterForEachMatchingNode(twoNodesFactory, build, listener);
+                    noMatchingNodeShouldYieldSameLabel(dummyNodesFactory, build, listener);
 
-                                } catch (DontTriggerException e) {
-                                    e.printStackTrace();
-                                    Assert.fail(e.getMessage());
-                                    return false;
-                                }
+                } catch (DontTriggerException e) {
+                    e.printStackTrace();
+                    Assert.fail(e.getMessage());
+                    return false;
+                }
 
-                                executed.add(Boolean.TRUE);
-                                return true;
-                            }
-                        });
+                executed.add(Boolean.TRUE);
+                return true;
+            }
+        });
 
         projectA.getBuildersList().add(createTriggerBuilder(projectB, twoNodesFactory));
         j.assertBuildStatus(
-                Result.SUCCESS, projectA.scheduleBuild2(0, new Cause.UserIdCause()).get());
+                Result.SUCCESS,
+                projectA.scheduleBuild2(0, new Cause.UserIdCause()).get());
         // make sure the test was really executed
         assertThat(executed).containsOnly(Boolean.TRUE);
     }
@@ -121,16 +116,12 @@ public class AllNodesForLabelBuildParameterFactoryUnitTest {
         assertThat(nodeNames).containsOnly("node2", "node3");
     }
 
-    private TriggerBuilder createTriggerBuilder(
-            AbstractProject<?, ?> project, AbstractBuildParameterFactory factory) {
-        TriggerBuilder tBuilder =
-                new TriggerBuilder(
-                        new BlockableBuildTriggerConfig(
-                                project.getName(),
-                                new BlockingBehaviour(
-                                        Result.FAILURE, Result.UNSTABLE, Result.FAILURE),
-                                Collections.singletonList(factory),
-                                Collections.emptyList()));
+    private TriggerBuilder createTriggerBuilder(AbstractProject<?, ?> project, AbstractBuildParameterFactory factory) {
+        TriggerBuilder tBuilder = new TriggerBuilder(new BlockableBuildTriggerConfig(
+                project.getName(),
+                new BlockingBehaviour(Result.FAILURE, Result.UNSTABLE, Result.FAILURE),
+                Collections.singletonList(factory),
+                Collections.emptyList()));
         return tBuilder;
     }
 }

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/NodeLabelBuildParameterTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/NodeLabelBuildParameterTest.java
@@ -40,7 +40,8 @@ import org.jvnet.jenkins.plugins.nodelabelparameter.LabelParameterDefinition;
 
 public class NodeLabelBuildParameterTest {
 
-    @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
     /**
      * Tests whether a job A is able to trigger job B to be executed on a specific node/slave. If it
@@ -60,18 +61,13 @@ public class NodeLabelBuildParameterTest {
         // create projectA, which triggers projectB with a given label parameter
         Project<?, ?> projectA = j.createFreeStyleProject("projectA");
         projectA.getPublishersList()
-                .add(
-                        new BuildTrigger(
-                                new BuildTriggerConfig(
-                                        "projectB",
-                                        ResultCondition.SUCCESS,
-                                        new NodeLabelBuildParameter(paramName, nodeName))));
+                .add(new BuildTrigger(new BuildTriggerConfig(
+                        "projectB", ResultCondition.SUCCESS, new NodeLabelBuildParameter(paramName, nodeName))));
 
         // create projectB, with a predefined parameter (same name as used in projectA!)
         FreeStyleProject projectB = j.createFreeStyleProject("projectB");
         ParametersDefinitionProperty pdp =
-                new ParametersDefinitionProperty(
-                        new LabelParameterDefinition(paramName, "some desc", "wrongNodeName"));
+                new ParametersDefinitionProperty(new LabelParameterDefinition(paramName, "some desc", "wrongNodeName"));
         projectB.addProperty(pdp);
         // CaptureEnvironmentBuilder builder = new CaptureEnvironmentBuilder();
         // projectB.getBuildersList().add(builder);

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/NodeListBuildParameterFactoryTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/NodeListBuildParameterFactoryTest.java
@@ -8,8 +8,7 @@ import org.junit.jupiter.api.Test;
 public class NodeListBuildParameterFactoryTest {
     @Test
     void testNodeListBuildParameterFactoryConstructor() {
-        NodeListBuildParameterFactory factory =
-                new NodeListBuildParameterFactory("labelName", "nodeListName");
+        NodeListBuildParameterFactory factory = new NodeListBuildParameterFactory("labelName", "nodeListName");
         assertThat(factory.name, is("labelName"));
         assertThat(factory.nodeListString, is("nodeListName"));
     }


### PR DESCRIPTION
## Use Palantir format instead of Google Java Format

From https://github.com/jenkinsci/cloud-stats-plugin/pull/68 :

Google Java Format is an excellent formatter for 2-space, 100 line codebases. Its Rectangle Rule has a high degree of conceptual purity, and this works well in the context of 2-space, 100 line codebases where it was designed. If starting from scratch, or if radical changes to existing code style were on the table, this would be my ideal formatter.

For existing 4-space, 120 line codebases where radical changes to existing code style are not on the table, Google Java Format has some critical flaws. Its 4-space "AOSP" mode does not work well at all, and it was not the primary use case. In practice the combination of 4-space mode and the rectangle rule results in unreadable code for lambdas. I have complained about this on the Google Java Format issue tracker for years, but no fix appears to be on the horizon. This makes sense, because Google internally uses the 2-space non-AOSP mode. While various PRs have been submitted to fix this problem, the maintainers of Google Java Format have rejected or ignored them, likely because they all violate the conceptual purity of the Rectangle Rule.

For existing 4-space, 120 line codebases (and the Jenkins project consists largely of these) where radical changes to existing code style are not on the table, Palantir Java Format is a better choice than Google Java Format. It is a fork of Google Java Format designed for this use case with intentional violations of the Rectangle Rule. In practice it gives much better results than Google Java Format for this type of codebase.

The Maven project is reformatting its legacy codebase with Palantir Java Format and I have been impressed with how relatively uneventful it has been. Palantir Java Format works very well with this type of codebase, and Jenkins is an example of this type of codebase as well. I have successfully reformatted plugin-compat-tester this way in jenkinsci/plugin-compat-tester#506 and the results are far better than Google Java Format.

As the Zen of Python states:

> Practicality beats purity

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
