### PR TITLE
Activate Spotless via Maven property rather than file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.60</version>
+    <version>4.61</version>
     <relativePath />
   </parent>
 
@@ -56,6 +56,7 @@
     <revision>1.12.0</revision>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
+    <spotless.check.skip>false</spotless.check.skip>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Many thanks for adopting the standard Spotless configuration, which has enabled me to streamline its activation in plugin parent POM 4.61. It is now possible to delete `.mvn_exec_spotless` and add `<spotless.check.skip>false</spotless.check.skip>` instead, which I think makes for a more readable configuration.