### PR TITLE
Require Jenkins 2.401.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
   <properties>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.387.3</jenkins.version>
+    <jenkins.version>2.401.3</jenkins.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <revision>1.12.1</revision>
     <spotbugs.effort>Max</spotbugs.effort>
@@ -63,8 +63,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
-        <version>2543.vfb_1a_5fb_9496d</version>
+        <artifactId>bom-2.401.x</artifactId>
+        <version>2555.v3190a_8a_c60c6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Require Jenkins 2.401.3 or newer

Jenkins 2.426.1 will release Nov 15, 2023.  When it releases, the recommendation for minimum Jenkins version support will increase to Jenkins 2.401.3.  Since the plugin bill of materials is no longer updating the 2.387.x line, this pull request switches to use Jenkins 2.401.x as the new minimum Jenkins version.

This change is not significant enough to require a new release of the plugin.  It is enough that when the next release happens, it will require Jenkins 2.401.3 or newer.

### Testing done

Confirmed that automated tests pass on Linux.  Rely on ci.jenkins.io to check Windows.  I've been using this plugin with recent Jenkins versions for a long time.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
