### PR TITLE
Remove deprecated usages of `ANTLRException`

### DIFF
--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinition.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinition.java
@@ -1,7 +1,6 @@
 /** */
 package org.jvnet.jenkins.plugins.nodelabelparameter;
 
-import antlr.ANTLRException;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -163,7 +162,7 @@ public class LabelParameterDefinition extends SimpleParameterDefinition
                 return matchingNodeCount == 0
                         ? FormValidation.warning(Messages.NodeLabelParameterDefinition_noNodeMatched(value))
                         : FormValidation.ok();
-            } catch (ANTLRException e) {
+            } catch (IllegalArgumentException e) {
                 return FormValidation.error(
                         Messages.NodeLabelParameterDefinition_labelExpressionNotValid(value, e.getMessage()));
             }
@@ -194,13 +193,13 @@ public class LabelParameterDefinition extends SimpleParameterDefinition
                         + "</b><ul><li>"
                         + html
                         + "</li></ul>");
-            } catch (ANTLRException e) {
+            } catch (IllegalArgumentException e) {
                 return FormValidation.error(
                         Messages.NodeLabelParameterDefinition_labelExpressionNotValid(label, e.getMessage()));
             }
         }
 
-        private Set<Node> getNodesForLabel(String labelExp) throws ANTLRException {
+        private Set<Node> getNodesForLabel(String labelExp) {
             Label label = LabelExpression.parseExpression(labelExp);
             return label.getNodes();
         }

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterValue.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterValue.java
@@ -1,7 +1,6 @@
 /** */
 package org.jvnet.jenkins.plugins.nodelabelparameter;
 
-import antlr.ANTLRException;
 import hudson.EnvVars;
 import hudson.Util;
 import hudson.model.AbstractBuild;
@@ -128,7 +127,7 @@ public class LabelParameterValue extends ParameterValue {
             for (Node node : label.getNodes()) {
                 nodeNames.add(node.getSelfLabel().getName());
             }
-        } catch (ANTLRException e) {
+        } catch (IllegalArgumentException e) {
             LOGGER.log(Level.SEVERE, "failed to parse label [" + labelExp + "]", e);
         }
         return nodeNames;


### PR DESCRIPTION
Replaces deprecated usages of `ANTLRException` with the more generic `IllegalArgumentException`, now documented in the core Javadoc.