### PR TITLE
Extend Windows timeout for a flaky test

### DIFF
--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/EnvironmentContributorTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/EnvironmentContributorTest.java
@@ -1,5 +1,6 @@
 package org.jvnet.jenkins.plugins.nodelabelparameter;
 
+import static hudson.Functions.isWindows;
 import static org.junit.Assert.*;
 
 import hudson.model.FreeStyleProject;
@@ -80,7 +81,7 @@ public class EnvironmentContributorTest {
         Assert.assertNull(projectB.getLastBuild());
 
         j.assertBuildStatusSuccess(projectA.scheduleBuild2(0));
-        j.waitUntilNoActivityUpTo(10000); // 10secs
+        j.waitUntilNoActivityUpTo(isWindows() ? 29000 : 10000); // 10secs on non-Windows, 29secs on Windows
 
         final String nodeName = j.jenkins.getSelfLabel().getName();
         Assert.assertEquals(nodeName, cA.getEnvVars().get("NODE_NAME"));


### PR DESCRIPTION
## Reduce Windows test flakiness with longer timeout

Windows test execution tends to be slower, especially for tests that are based on JenkinsRule.  Allow extra time to complete the tests.

### Testing done

Confirmed tests pass on Linux.  Will use ci.jenkins.io to test the pull request multiple times before it is merged.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
