### PR TITLE
Prevent null pointer exceptions in NextLabelCause

### DIFF
--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NextLabelCause.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NextLabelCause.java
@@ -2,6 +2,7 @@ package org.jvnet.jenkins.plugins.nodelabelparameter;
 
 import hudson.model.Cause.UpstreamCause;
 import hudson.model.Run;
+import java.util.Objects;
 
 /**
  * @author domi
@@ -34,13 +35,16 @@ public class NextLabelCause extends UpstreamCause {
 
         NextLabelCause that = (NextLabelCause) o;
 
-        return label.equals(that.label);
+        return Objects.equals(label, that.label);
     }
 
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + label.hashCode();
+        result = 31 * result;
+        if (label != null) {
+            result = result + label.hashCode();
+        }
         return result;
     }
 }

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NextLabelCauseTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NextLabelCauseTest.java
@@ -3,7 +3,6 @@ package org.jvnet.jenkins.plugins.nodelabelparameter;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -21,21 +20,12 @@ public class NextLabelCauseTest {
         NextLabelCause cause = new NextLabelCause("dummylabel", build);
         String description = cause.getShortDescription();
         Assert.assertEquals(description, "A build with label/node [dummylabel] was requested");
-
-        NextLabelCause causeA = new NextLabelCause(null, build);
-        NextLabelCause causeB = new NextLabelCause(null, build);
-        /* Temporary check that hashCode does not NPE on null label */
-        Assert.assertEquals(causeA.hashCode(), causeB.hashCode());
-        /* Temporary check that equals does not NPE on null label */
-        Assert.assertTrue(causeA.equals(causeB));
     }
 
     @Test
     public void testEqualsContract() {
-        EqualsVerifier.forClass(LabelParameterValue.class)
-                .usingGetClass()
-                .suppress(Warning.NONFINAL_FIELDS)
-                .withIgnoredFields("description", "nextLabels")
-                .verify();
+        // The UpstreamCause base class of NextLabelCause complicates the equals contract.
+        // Intentionally use the simple() verifier.
+        EqualsVerifier.simple().forClass(NextLabelCause.class).verify();
     }
 }

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NextLabelCauseTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NextLabelCauseTest.java
@@ -21,6 +21,13 @@ public class NextLabelCauseTest {
         NextLabelCause cause = new NextLabelCause("dummylabel", build);
         String description = cause.getShortDescription();
         Assert.assertEquals(description, "A build with label/node [dummylabel] was requested");
+
+        NextLabelCause causeA = new NextLabelCause(null, build);
+        NextLabelCause causeB = new NextLabelCause(null, build);
+        /* Temporary check that hashCode does not NPE on null label */
+        Assert.assertEquals(causeA.hashCode(), causeB.hashCode());
+        /* Temporary check that equals does not NPE on null label */
+        Assert.assertTrue(causeA.equals(causeB));
     }
 
     @Test


### PR DESCRIPTION
## Prevent null pointer exceptions in NextLabelCause

The equals method and the hashCode method both would throw a null pointer exception if the label in the constructor was null.  I doubt that the label in the constructor has ever been null, but it is easy to safeguard those two methods so that they are null-safe.
    
The code incorrectly tested the equals contract of the wrong class due to my copy and paste error.  Test the correct class.

Uses the simple() verifier because the UpstreamCause class seems to have complications related to its superclass and I'd rather not spend the time to investigate further.  The simple() verifier detected the null pointer exceptions, so it is still better than not testing.

Special thanks to @code-arnab for detecting and reporting the mistake in https://github.com/jenkinsci/nodelabelparameter-plugin/pull/371#issuecomment-2560702487

### Testing done

Automated tests pass locally on Linux.  Rely on ci.jenkins.io to test Windows.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
