### PR TITLE
Use symbol for build history badge and consistent styling for parameter lists

### DIFF
--- a/src/main/resources/org/jvnet/jenkins/plugins/nodelabelparameter/LabelBadgeAction/badge.jelly
+++ b/src/main/resources/org/jvnet/jenkins/plugins/nodelabelparameter/LabelBadgeAction/badge.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-	<l:icon class="icon-computer icon-sm" title="${it.tooltip}"/>
+	<l:icon src="symbol-computer" class="icon-sm" title="${it.tooltip}"/>
 </j:jelly>

--- a/src/main/resources/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition/config.jelly
+++ b/src/main/resources/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition/config.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
 	</f:entry>
 	
     <f:entry name="defaultSlaves" title="Default nodes" description="${%defaultNodes}">
-        <select name="defaultSlaves" multiple="multiple" size="5">
+        <select class="jenkins-select__input" name="defaultSlaves" multiple="multiple" size="5">
             <j:invokeStatic className="org.jvnet.jenkins.plugins.nodelabelparameter.NodeParameterDefinition" method="getSlaveNames" var="allNodes" />
             <j:forEach var="aNode" items="${allNodes}" varStatus="loop">
                 <j:choose>
@@ -53,7 +53,7 @@ THE SOFTWARE.
     </f:entry>
 		
 	<f:entry name="allowedSlaves" title="Possible nodes" description="${%selectableNodes}">
-		<select name="allowedSlaves" multiple="multiple" size="5">
+		<select class="jenkins-select__input" name="allowedSlaves" multiple="multiple" size="5">
 			<j:invokeStatic className="org.jvnet.jenkins.plugins.nodelabelparameter.NodeParameterDefinition" method="getSlaveNamesForSelection" var="allNodes" />
 			<j:forEach var="aNode" items="${allNodes}" varStatus="loop">
 				<j:choose>

--- a/src/main/resources/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition/index.jelly
+++ b/src/main/resources/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition/index.jelly
@@ -27,6 +27,7 @@ THE SOFTWARE.
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
 	<j:set var="escapeEntryTitleAndDescription" value="false"/>
+	<st:adjunct includes="org.jvnet.jenkins.plugins.nodelabelparameter.NodeParameterDefinition.style"/>
 	<f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
 		<!-- this div is required because of ParametersDefinitionProperty.java#117 -->
 		<div name="parameter" description="${it.description}">
@@ -34,7 +35,7 @@ THE SOFTWARE.
 			
 			<j:choose>
 				<j:when test="${it.allowMultiNodeSelection == true}">
-					<select name="value" multiple="multiple" size="${it.allowedNodesOrAll.size()}">
+					<select class="jenkins-select__input nlp-no-scroll" name="value" multiple="multiple" size="${it.allowedNodesOrAll.size()}">
 						<j:forEach var="aNode" items="${it.allowedNodesOrAll}"
 							varStatus="loop">
 							<j:choose>
@@ -49,18 +50,20 @@ THE SOFTWARE.
 					</select>
 				</j:when>
 				<j:otherwise>
-					<select name="value">
-						<j:forEach var="aNode" items="${it.allowedNodesOrAll}" varStatus="loop">
-							<j:choose>
-								<j:when test="${it.defaultSlaves.contains(aNode)}">
-									<option value="${aNode}" selected="selected">${aNode}</option>
-								</j:when>
-								<j:otherwise>
-									<option value="${aNode}">${aNode}</option>
-								</j:otherwise>
-							</j:choose>
-						</j:forEach>
-					</select>
+					<div class="jenkins-select">
+						<select class="jenkins-select__input" name="value">
+							<j:forEach var="aNode" items="${it.allowedNodesOrAll}" varStatus="loop">
+								<j:choose>
+									<j:when test="${it.defaultSlaves.contains(aNode)}">
+										<option value="${aNode}" selected="selected">${aNode}</option>
+									</j:when>
+									<j:otherwise>
+										<option value="${aNode}">${aNode}</option>
+									</j:otherwise>
+								</j:choose>
+							</j:forEach>
+						</select>
+					</div>
 				</j:otherwise>
 			</j:choose>
 		</div>

--- a/src/main/resources/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition/style.css
+++ b/src/main/resources/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinition/style.css
@@ -1,0 +1,3 @@
+.nlp-no-scroll {
+  overflow-y: hidden;
+}


### PR DESCRIPTION
## Use symbol for build history badge and consistent styling for parameter lists

- use a symbol for the badge
- apply Jenkins style to the select for the node parameter. Suppress the scrollbar when multiple hsot can be selected

Before:
![image](https://github.com/user-attachments/assets/f589830c-e427-49cb-a6c3-7f7982bfa2ab)

After:
![image](https://github.com/user-attachments/assets/3f9864fd-9b0b-4263-8553-d2c5da17c888)


<!-- Please describe your pull request here. -->

### Testing done
Manual interactive testing

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
