### PR TITLE
[JENKINS-69756] Improve test coverage for AllNodesForLabelBuildParameterFactory

### DIFF
--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesForLabelBuildParameterFactoryUnitTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/parameterizedtrigger/AllNodesForLabelBuildParameterFactoryUnitTest.java
@@ -2,6 +2,7 @@ package org.jvnet.jenkins.plugins.nodelabelparameter.parameterizedtrigger;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -140,14 +141,10 @@ class AllNodesForLabelBuildParameterFactoryUnitTest {
         String log = logOutput.toString(StandardCharsets.UTF_8);
 
         // Verify the exception was caught and handled:
-        assertTrue(
-                log.contains("MacroEvaluationException") || log.contains("Exception"),
-                "Log should contain exception information");
+        assertThat(log, containsString("MacroEvaluationException: Error processing tokens"));
 
         // 2. Verify the original label was used (as set in the catch block)
-        assertTrue(
-                log.contains("Getting all nodes with label: " + malformedMacro),
-                "Log should show the original label was used");
+        assertThat(log, containsString("Getting all nodes with label: " + malformedMacro));
     }
 
     @Test
@@ -174,11 +171,9 @@ class AllNodesForLabelBuildParameterFactoryUnitTest {
         String log = logOutput.toString(StandardCharsets.UTF_8);
 
         // assert skipping offline
-        assertTrue(
-                log.contains(Messages.NodeListBuildParameterFactory_skippOfflineNode(nodeName)),
-                "Log should contain message about skipping offline node");
+        assertThat(log, containsString(Messages.NodeListBuildParameterFactory_skippOfflineNode(nodeName)));
         // assert no online nodes found -> indicates params were empty
-        assertTrue(log.contains(Messages.NodeListBuildParameterFactory_noOnlineNodeFound(factory.nodeLabel)));
+        assertThat(log, containsString(Messages.NodeListBuildParameterFactory_noOnlineNodeFound(factory.nodeLabel)));
     }
 
     @Test
@@ -224,7 +219,7 @@ class AllNodesForLabelBuildParameterFactoryUnitTest {
         // Get the log to verify messaging
         String log = logOutput.toString(StandardCharsets.UTF_8);
 
-        assertTrue(log.contains("Found nodes:"), "Log should indicate nodes were found");
+        assertThat(log, containsString("Found nodes:"));
     }
 
     private DumbSlave createDumbSlaveNode(String nodeName, String nodeLabel, Boolean isOffline) throws Exception {


### PR DESCRIPTION
Part of [JENKINS-69756](https://issues.jenkins.io/browse/JENKINS-69756)
## What I've done?
- Implemented a test cases to cover scenarios in getParams method
	1. Expect method to catch MacroEvaluationException
	2. Expect method to handle online and offline nodes correctly when ignoreOffline == true
## Test coverage before  
![image](https://github.com/user-attachments/assets/c7024080-9613-462b-bf68-377cbd96cf8b)
![image](https://github.com/user-attachments/assets/29d1e98d-b853-4b9f-9ffa-8b99fe6890b9)

## Test coverage after
![image](https://github.com/user-attachments/assets/49d45691-5de2-4895-8aeb-59eb63bb00ee)
![image](https://github.com/user-attachments/assets/acd2d6b4-170a-495b-a64c-eaba3fd3e736)

## Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
