### PR TITLE
[JENKINS-69756] Improved test coverage.

### DIFF
--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeUtil.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeUtil.java
@@ -15,12 +15,23 @@ public final class NodeUtil {
      * @return <code>true</code> if the job is ok to be used
      */
     public static boolean isNodeOnline(String nodeName) {
-        String controllerLabel = Jenkins.get().getSelfLabel().getName();
+        return isNodeOnline(nodeName, Jenkins.get());
+    }
+
+    /**
+     * Checks whether the given node is available for an execution of the job,
+     *
+     * @param nodeName the name of the node to check
+     * @param jenkins  the Jenkins instance to use
+     * @return <code>true</code> if the job is ok to be used
+     */
+    public static boolean isNodeOnline(String nodeName, Jenkins jenkins) {
+        String controllerLabel = jenkins.getSelfLabel().getName();
         if (controllerLabel.equals(nodeName)) {
             return true;
         }
 
-        final Computer c = Jenkins.get().getComputer(nodeName);
+        final Computer c = jenkins.getComputer(nodeName);
         if (c != null) {
             Node n = c.getNode();
             // really check if the node is available for execution

--- a/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeUtil.java
+++ b/src/main/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeUtil.java
@@ -15,23 +15,12 @@ public final class NodeUtil {
      * @return <code>true</code> if the job is ok to be used
      */
     public static boolean isNodeOnline(String nodeName) {
-        return isNodeOnline(nodeName, Jenkins.get());
-    }
-
-    /**
-     * Checks whether the given node is available for an execution of the job,
-     *
-     * @param nodeName the name of the node to check
-     * @param jenkins  the Jenkins instance to use
-     * @return <code>true</code> if the job is ok to be used
-     */
-    public static boolean isNodeOnline(String nodeName, Jenkins jenkins) {
-        String controllerLabel = jenkins.getSelfLabel().getName();
+        String controllerLabel = Jenkins.get().getSelfLabel().getName();
         if (controllerLabel.equals(nodeName)) {
             return true;
         }
 
-        final Computer c = jenkins.getComputer(nodeName);
+        final Computer c = Jenkins.get().getComputer(nodeName);
         if (c != null) {
             Node n = c.getNode();
             // really check if the node is available for execution

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelBadgeActionTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelBadgeActionTest.java
@@ -1,0 +1,64 @@
+package org.jvnet.jenkins.plugins.nodelabelparameter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+public class LabelBadgeActionTest {
+
+    @Test
+    void testLabelBadgeAction() {
+        // Test with a regular label and tooltip
+        String testLabel = "test-label";
+        String testTooltip = "This is a test tooltip";
+        LabelBadgeAction badge = new LabelBadgeAction(testLabel, testTooltip);
+
+        // Verify getIconFileName returns null (by design)
+        assertNull(badge.getIconFileName());
+
+        // Verify getUrlName returns null (by design)
+        assertNull(badge.getUrlName());
+
+        // Verify getDisplayName returns null (by design)
+        assertNull(badge.getDisplayName());
+
+        // Verify getLabel returns the label
+        assertEquals(testLabel, badge.getLabel());
+
+        // Verify getTooltip returns the tooltip
+        assertEquals(testTooltip, badge.getTooltip());
+    }
+
+    @Test
+    void testLabelBadgeActionWithSpecialChars() {
+        // Test with a label and tooltip containing special characters
+        String specialLabel = "test-label with spaces & special chars: !@#$%^&*()";
+        String specialTooltip = "Tooltip with special chars: !@#$%^&*()";
+        LabelBadgeAction badge = new LabelBadgeAction(specialLabel, specialTooltip);
+
+        // Verify label and tooltip handle special characters
+        assertEquals(specialLabel, badge.getLabel());
+        assertEquals(specialTooltip, badge.getTooltip());
+    }
+
+    @Test
+    void testLabelBadgeActionWithEmptyStrings() {
+        // Test with empty label and tooltip
+        LabelBadgeAction badge = new LabelBadgeAction("", "");
+
+        // Verify behavior with empty strings
+        assertEquals("", badge.getLabel());
+        assertEquals("", badge.getTooltip());
+    }
+
+    @Test
+    void testLabelBadgeActionWithNullValues() {
+        // Test with null label and tooltip
+        LabelBadgeAction badge = new LabelBadgeAction(null, null);
+
+        // Verify null is handled gracefully
+        assertNull(badge.getLabel());
+        assertNull(badge.getTooltip());
+    }
+}

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeUtilTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeUtilTest.java
@@ -35,7 +35,7 @@ public class NodeUtilTest {
         j.waitOnline(slave);
 
         // The node should be considered online
-        assertTrue(NodeUtil.isNodeOnline(nodeName, j.jenkins));
+        assertTrue(NodeUtil.isNodeOnline(nodeName));
     }
 
     @Test
@@ -57,13 +57,13 @@ public class NodeUtilTest {
         }
 
         // The node should be considered offline
-        assertFalse(NodeUtil.isNodeOnline(nodeName, j.jenkins));
+        assertFalse(NodeUtil.isNodeOnline(nodeName));
     }
 
     @Test
     void testIsNodeOnlineWithNonExistentNode(JenkinsRule j) {
         // A non-existent node should not be considered online
-        assertFalse(NodeUtil.isNodeOnline("non-existent-node-" + System.currentTimeMillis(), j.jenkins));
+        assertFalse(NodeUtil.isNodeOnline("non-existent-node-" + System.currentTimeMillis()));
     }
 
     @Test
@@ -81,6 +81,6 @@ public class NodeUtilTest {
         j.waitOnline(slave);
 
         // The node should be considered online even with just 1 executor
-        assertTrue(NodeUtil.isNodeOnline(nodeName, j.jenkins));
+        assertTrue(NodeUtil.isNodeOnline(nodeName));
     }
 }

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeUtilTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeUtilTest.java
@@ -1,0 +1,86 @@
+package org.jvnet.jenkins.plugins.nodelabelparameter;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.model.Computer;
+import hudson.model.Label;
+import hudson.slaves.DumbSlave;
+import hudson.slaves.OfflineCause;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+public class NodeUtilTest {
+
+    @Test
+    void testIsNodeOnlineWithBuiltInNode(JenkinsRule j) {
+        // The built-in node (controller) is always online
+        String controllerLabel = j.jenkins.getSelfLabel().getName();
+
+        // Just test that the built-in node exists
+        Label label = j.jenkins.getLabel(controllerLabel);
+        assertTrue(label != null, "Built-in node label should exist");
+    }
+
+    @Test
+    void testIsNodeOnlineWithOnlineNode(JenkinsRule j) throws Exception {
+        // Create a test online node
+        String nodeName = "test-online-node-" + System.currentTimeMillis();
+        DumbSlave slave = j.createSlave(nodeName, "", null);
+
+        // Wait for the node to be fully online
+        j.waitOnline(slave);
+
+        // The node should be considered online
+        assertTrue(NodeUtil.isNodeOnline(nodeName, j.jenkins));
+    }
+
+    @Test
+    void testIsNodeOnlineWithOfflineNode(JenkinsRule j) throws Exception {
+        // Create a test node that will be taken offline
+        String nodeName = "test-offline-node-" + System.currentTimeMillis();
+        DumbSlave slave = j.createSlave(nodeName, "", null);
+
+        // Wait for the node to be fully online first
+        j.waitOnline(slave);
+
+        // Take the node offline
+        Computer computer = slave.toComputer();
+        computer.disconnect(new OfflineCause.ByCLI("Taking offline for testing"));
+
+        // Wait for it to go offline
+        while (computer.isOnline()) {
+            Thread.sleep(100);
+        }
+
+        // The node should be considered offline
+        assertFalse(NodeUtil.isNodeOnline(nodeName, j.jenkins));
+    }
+
+    @Test
+    void testIsNodeOnlineWithNonExistentNode(JenkinsRule j) {
+        // A non-existent node should not be considered online
+        assertFalse(NodeUtil.isNodeOnline("non-existent-node-" + System.currentTimeMillis(), j.jenkins));
+    }
+
+    @Test
+    void testIsNodeOnlineWithNodeWithLowExecutors(JenkinsRule j) throws Exception {
+        // Create a test node with 1 executor
+        String nodeName = "test-low-exec-node-" + System.currentTimeMillis();
+        DumbSlave slave = j.createSlave(nodeName, "", null);
+
+        // Set the number of executors to 1 (minimum valid value)
+        slave.setNumExecutors(1);
+        Future<?> future = slave.toComputer().connect(false);
+        future.get(); // Wait for the connection to complete
+
+        // Wait for the node to be fully online
+        j.waitOnline(slave);
+
+        // The node should be considered online even with just 1 executor
+        assertTrue(NodeUtil.isNodeOnline(nodeName, j.jenkins));
+    }
+}

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/node/NodeEligibilityTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/node/NodeEligibilityTest.java
@@ -1,0 +1,45 @@
+package org.jvnet.jenkins.plugins.nodelabelparameter.node;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.jvnet.jenkins.plugins.nodelabelparameter.Messages;
+
+/**
+ * Simple unit test for NodeEligibility implementations.
+ * Testing only basic functionality that can be tested without complex mocking.
+ * More complex functionality would require integration tests with actual
+ * Jenkins setup.
+ */
+public class NodeEligibilityTest {
+
+    @Test
+    void testAllNodeEligibilityDescriptor() {
+        // Test descriptors
+        AllNodeEligibility.Descriptor descriptor = new AllNodeEligibility.Descriptor();
+        assertEquals(
+                Messages.NodeEligibility_allNodes(),
+                descriptor.getDisplayName(),
+                "Descriptor display name should match Messages.properties");
+    }
+
+    @Test
+    void testIgnoreOfflineNodeEligibilityDescriptor() {
+        // Test descriptors
+        IgnoreOfflineNodeEligibility.Descriptor descriptor = new IgnoreOfflineNodeEligibility.Descriptor();
+        assertEquals(
+                Messages.NodeEligibility_ignoreOffline(),
+                descriptor.getDisplayName(),
+                "Descriptor display name should match Messages.properties");
+    }
+
+    @Test
+    void testIgnoreTempOfflineNodeEligibilityDescriptor() {
+        // Test descriptors
+        IgnoreTempOfflineNodeEligibility.Descriptor descriptor = new IgnoreTempOfflineNodeEligibility.Descriptor();
+        assertEquals(
+                Messages.NodeEligibility_ignoreTmpOffline(),
+                descriptor.getDisplayName(),
+                "Descriptor display name should match Messages.properties");
+    }
+}

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/wrapper/TriggerNextBuildWrapperTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/wrapper/TriggerNextBuildWrapperTest.java
@@ -1,0 +1,137 @@
+package org.jvnet.jenkins.plugins.nodelabelparameter.wrapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import hudson.Extension;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Result;
+import hudson.slaves.DumbSlave;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.jvnet.jenkins.plugins.nodelabelparameter.Constants;
+import org.jvnet.jenkins.plugins.nodelabelparameter.LabelParameterDefinition;
+import org.jvnet.jenkins.plugins.nodelabelparameter.LabelParameterValue;
+import org.jvnet.jenkins.plugins.nodelabelparameter.node.AllNodeEligibility;
+
+@WithJenkins
+public class TriggerNextBuildWrapperTest {
+
+    @Test
+    void testTriggerBuildsConcurrent(JenkinsRule j) throws Exception {
+        // Create multiple slaves
+        String labelPrefix = "concurrent-label-";
+        DumbSlave slave1 = j.createSlave(labelPrefix + "1", null, null);
+        DumbSlave slave2 = j.createSlave(labelPrefix + "2", null, null);
+        DumbSlave slave3 = j.createSlave(labelPrefix + "3", null, null);
+
+        // Wait for slaves to come online
+        j.waitOnline(slave1);
+        j.waitOnline(slave2);
+        j.waitOnline(slave3);
+
+        // Create project with concurrent builds enabled
+        FreeStyleProject project = j.createFreeStyleProject("concurrent-project");
+        project.setConcurrentBuild(true);
+
+        // Create a label parameter with multiple nodes
+        String paramName = "NODES";
+        List<String> nodeLabels = new ArrayList<>();
+        nodeLabels.add(labelPrefix + "1");
+        nodeLabels.add(labelPrefix + "2");
+        nodeLabels.add(labelPrefix + "3");
+
+        LabelParameterDefinition labelParam = new LabelParameterDefinition(
+                paramName, "description", nodeLabels.get(0), true, false, Constants.ALL_CASES);
+        project.addProperty(new ParametersDefinitionProperty(labelParam));
+
+        // Trigger a build with all three labels
+        LabelParameterValue labelParamValue = new LabelParameterValue(paramName, nodeLabels, new AllNodeEligibility());
+        FreeStyleBuild build =
+                project.scheduleBuild2(0, new ParametersAction(labelParamValue)).get();
+
+        j.assertBuildStatusSuccess(build);
+
+        // Wait for all builds to complete
+        j.waitUntilNoActivity();
+
+        // There should be 3 total builds (original + 2 triggered)
+        assertEquals(3, project.getBuilds().size());
+    }
+
+    @Test
+    void testTriggerNextBuildWithFailure(JenkinsRule j) throws Exception {
+        // Create multiple slaves
+        String labelPrefix = "sequential-label-";
+        DumbSlave slave1 = j.createSlave(labelPrefix + "1", null, null);
+        DumbSlave slave2 = j.createSlave(labelPrefix + "2", null, null);
+
+        // Wait for slaves to come online
+        j.waitOnline(slave1);
+        j.waitOnline(slave2);
+
+        // Create project with sequential builds
+        FreeStyleProject project = j.createFreeStyleProject("sequential-project");
+        project.setConcurrentBuild(false);
+
+        // Create a label parameter with multiple nodes
+        String paramName = "NODES";
+        List<String> nodeLabels = new ArrayList<>();
+        nodeLabels.add(labelPrefix + "1");
+        nodeLabels.add(labelPrefix + "2");
+
+        // Set triggerIfResult to SUCCESS - if build fails, it should not trigger next
+        // build
+        LabelParameterDefinition labelParam = new LabelParameterDefinition(
+                paramName, "description", nodeLabels.get(0), true, false, Constants.CASE_SUCCESS);
+        project.addProperty(new ParametersDefinitionProperty(labelParam));
+
+        // Add a build step that makes the build fail
+        project.getBuildersList().add(new FailureBuilder());
+
+        // Trigger a build with both labels
+        LabelParameterValue labelParamValue = new LabelParameterValue(paramName, nodeLabels, new AllNodeEligibility());
+        FreeStyleBuild build =
+                project.scheduleBuild2(0, new ParametersAction(labelParamValue)).get();
+
+        j.assertBuildStatus(Result.FAILURE, build);
+
+        // Wait for all builds to complete
+        j.waitUntilNoActivity();
+
+        // There should be only 1 build since the build failed
+        assertEquals(1, project.getBuilds().size());
+    }
+
+    /**
+     * A builder that makes the build fail.
+     */
+    public static class FailureBuilder extends Builder {
+        @Override
+        public boolean perform(
+                hudson.model.AbstractBuild<?, ?> build, hudson.Launcher launcher, hudson.model.BuildListener listener) {
+            build.setResult(Result.FAILURE);
+            return false;
+        }
+
+        @Extension
+        public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
+            @Override
+            public boolean isApplicable(Class jobType) {
+                return true;
+            }
+
+            @Override
+            public String getDisplayName() {
+                return "Make build fail";
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Refactor NodeUtil to accept Jenkins instance in isNodeOnline method and add unit tests for NodeUtil and LabelBadgeAction

<!-- Refactor NodeUtil to accept Jenkins instance in isNodeOnline method and add unit tests for NodeUtil and LabelBadgeAction -->
[JENKINS-69756](https://issues.jenkins.io/browse/JENKINS-69756?jql=labels%20%3D%20newbie-friendly%20and%20status%20in%20(Open%2C%20%22To%20Do%22%2C%20Reopened))
### Testing done

### Before
![image](https://github.com/user-attachments/assets/5a931e8b-68c8-4b57-94eb-98668eb65ae1)

### After
![image](https://github.com/user-attachments/assets/ddffe253-209d-4f38-a08c-17ea7f1589f9)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
