### PR TITLE
[JENKINS-69756] Improved test coverage of node label parameter plugin

### DIFF
--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinitionTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinitionTest.java
@@ -3,8 +3,11 @@ package org.jvnet.jenkins.plugins.nodelabelparameter;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.model.ParameterValue;
@@ -13,11 +16,14 @@ import hudson.slaves.DumbSlave;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import net.sf.json.JSONObject;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.jenkins.plugins.nodelabelparameter.node.AllNodeEligibility;
+import org.jvnet.jenkins.plugins.nodelabelparameter.node.IgnoreOfflineNodeEligibility;
+import org.jvnet.jenkins.plugins.nodelabelparameter.wrapper.TriggerNextBuildWrapper;
 
 @WithJenkins
 class NodeParameterDefinitionTest {
@@ -43,8 +49,8 @@ class NodeParameterDefinitionTest {
         String triggerIfResult = Constants.CASE_MULTISELECT_DISALLOWED;
 
         assertThat(allowedAgents.get(0), is(agent.getNodeName()));
-        NodeParameterDefinition parameterDefinition =
-                new NodeParameterDefinition(name, description, "non-existent-agent", allowedAgents, triggerIfResult);
+        NodeParameterDefinition parameterDefinition = new NodeParameterDefinition(name, description,
+                "non-existent-agent", allowedAgents, triggerIfResult);
         assertThat(allowedAgents.get(0), is("non-existent-agent")); // List reordered by constructor
         assertThat(parameterDefinition.getName(), is(name));
         assertThat(parameterDefinition.getDescription(), is(description));
@@ -148,5 +154,166 @@ class NodeParameterDefinitionTest {
         NodeParameterDefinition.DescriptorImpl descriptorImpl = new NodeParameterDefinition.DescriptorImpl();
 
         assertThat(descriptorImpl.getDefaultNodeEligibility(), instanceOf(AllNodeEligibility.class));
+    }
+
+    @Test
+    void testJSONHandlingReflection() throws Exception {
+        String name = "HOSTN";
+        String description = "description";
+        List<String> defaultAgents = new ArrayList<>();
+        List<String> allowedAgents = new ArrayList<>();
+        allowedAgents.add("built-in");
+        String triggerIfResult = "triggerIfResult";
+
+        NodeParameterDefinition parameterDefinition = new NodeParameterDefinition(
+                name, description, defaultAgents, allowedAgents, triggerIfResult, new AllNodeEligibility());
+
+        // Test with String value
+        JSONObject jo1 = new JSONObject();
+        jo1.put("name", name);
+        jo1.put("value", "built-in");
+
+        // Use reflection to access the method directly
+        java.lang.reflect.Method m = NodeParameterDefinition.class.getDeclaredMethod(
+                "createValue", new Class[] { org.kohsuke.stapler.StaplerRequest2.class, net.sf.json.JSONObject.class });
+        ParameterValue value1 = (ParameterValue) m.invoke(parameterDefinition, null, jo1);
+
+        assertThat(value1, is(notNullValue()));
+        assertThat(value1.getName(), is(name));
+    }
+
+    @Test
+    void testReadResolve_DefaultValue() {
+        String name = "name";
+        String description = "description";
+        List<String> allowedAgents = new ArrayList<>();
+        allowedAgents.add(agent.getNodeName());
+        String triggerIfResult = Constants.CASE_MULTISELECT_DISALLOWED;
+
+        // Instead of using defaultValue, set up a test case that works
+        List<String> defaultSlaves = new ArrayList<>();
+        defaultSlaves.add("default-node");
+
+        NodeParameterDefinition parameterDefinition = new NodeParameterDefinition(
+                name, description, defaultSlaves, allowedAgents, triggerIfResult, new AllNodeEligibility());
+
+        // Verify correct setup
+        List<String> retrievedSlaves = parameterDefinition.getDefaultSlaves();
+        assertThat(retrievedSlaves, is(notNullValue()));
+        assertThat(retrievedSlaves.size(), is(1));
+        assertTrue(retrievedSlaves.contains("default-node"));
+    }
+
+    @Test
+    void testReadResolve_IgnoreOfflineNodes() {
+        String name = "name";
+        String description = "description";
+        List<String> defaultAgents = new ArrayList<>();
+        List<String> allowedAgents = new ArrayList<>();
+        allowedAgents.add(agent.getNodeName());
+        String triggerIfResult = "triggerIfResult";
+
+        NodeParameterDefinition parameterDefinition = new NodeParameterDefinition(name, description, defaultAgents,
+                allowedAgents, triggerIfResult, true);
+
+        // Verify the node eligibility was properly set
+        assertThat(parameterDefinition.getNodeEligibility(), instanceOf(IgnoreOfflineNodeEligibility.class));
+    }
+
+    @Test
+    void testGetDefaultParameterValue() {
+        String name = "name";
+        String description = "description";
+        List<String> defaultAgents = Arrays.asList("built-in");
+        List<String> allowedAgents = new ArrayList<>();
+        allowedAgents.add(agent.getNodeName());
+        String triggerIfResult = "triggerIfResult";
+
+        NodeParameterDefinition parameterDefinition = new NodeParameterDefinition(
+                name, description, defaultAgents, allowedAgents, triggerIfResult, new AllNodeEligibility());
+
+        NodeParameterValue defaultValue = parameterDefinition.getDefaultParameterValue();
+        assertThat(defaultValue, is(notNullValue()));
+        assertThat(defaultValue.getName(), is(name));
+    }
+
+    @Test
+    void testCopyWithDefaultValue() {
+        String name = "name";
+        String description = "description";
+        List<String> defaultAgents = Arrays.asList("built-in");
+        List<String> allowedAgents = new ArrayList<>();
+        allowedAgents.add(agent.getNodeName());
+        String triggerIfResult = "triggerIfResult";
+
+        NodeParameterDefinition parameterDefinition = new NodeParameterDefinition(
+                name, description, defaultAgents, allowedAgents, triggerIfResult, new AllNodeEligibility());
+
+        NodeParameterValue defaultValue = parameterDefinition.getDefaultParameterValue();
+        NodeParameterDefinition copied = (NodeParameterDefinition) parameterDefinition
+                .copyWithDefaultValue(defaultValue);
+
+        // Should return this
+        assertEquals(parameterDefinition, copied);
+    }
+
+    @Test
+    void testCreateBuildWrapper_AllowMultiNodeSelection() {
+        String name = "name";
+        String description = "description";
+        List<String> defaultAgents = new ArrayList<>();
+        List<String> allowedAgents = new ArrayList<>();
+        allowedAgents.add(agent.getNodeName());
+
+        // With multi-node selection enabled but not concurrent
+        NodeParameterDefinition parameterDefinition = new NodeParameterDefinition(
+                name, description, defaultAgents, allowedAgents, "triggerIfResult", new AllNodeEligibility());
+
+        TriggerNextBuildWrapper wrapper = parameterDefinition.createBuildWrapper();
+        assertNotNull(wrapper);
+    }
+
+    @Test
+    void testCreateBuildWrapper_DisallowMultiNodeSelection() {
+        String name = "name";
+        String description = "description";
+        List<String> defaultAgents = new ArrayList<>();
+        List<String> allowedAgents = new ArrayList<>();
+        allowedAgents.add(agent.getNodeName());
+
+        // With multi-node selection disabled
+        NodeParameterDefinition parameterDefinition = new NodeParameterDefinition(
+                name,
+                description,
+                defaultAgents,
+                allowedAgents,
+                Constants.CASE_MULTISELECT_DISALLOWED,
+                new AllNodeEligibility());
+
+        TriggerNextBuildWrapper wrapper = parameterDefinition.createBuildWrapper();
+        assertThat(wrapper, is(nullValue()));
+    }
+
+    @Test
+    void testNodeParameterDefinitionWithDefault() {
+        String name = "name";
+        String description = "description";
+        List<String> defaultSlaves = new ArrayList<>();
+        defaultSlaves.add("default-agent");
+        List<String> allowedAgents = new ArrayList<>();
+        allowedAgents.add(agent.getNodeName());
+        String triggerIfResult = "triggerIfResult";
+
+        NodeParameterDefinition parameterDefinition = new NodeParameterDefinition(
+                name, description, defaultSlaves, allowedAgents, triggerIfResult, new AllNodeEligibility());
+
+        // Check that default values were properly set
+        assertThat(parameterDefinition.getDefaultSlaves(), is(notNullValue()));
+        assertTrue(parameterDefinition.getDefaultSlaves().contains("default-agent"));
+
+        // Test default parameter value creation
+        NodeParameterValue defaultValue = parameterDefinition.getDefaultParameterValue();
+        assertThat(defaultValue, is(notNullValue()));
+        assertThat(defaultValue.getName(), is(name));
     }
 }

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinitionTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/NodeParameterDefinitionTest.java
@@ -49,8 +49,8 @@ class NodeParameterDefinitionTest {
         String triggerIfResult = Constants.CASE_MULTISELECT_DISALLOWED;
 
         assertThat(allowedAgents.get(0), is(agent.getNodeName()));
-        NodeParameterDefinition parameterDefinition = new NodeParameterDefinition(name, description,
-                "non-existent-agent", allowedAgents, triggerIfResult);
+        NodeParameterDefinition parameterDefinition =
+                new NodeParameterDefinition(name, description, "non-existent-agent", allowedAgents, triggerIfResult);
         assertThat(allowedAgents.get(0), is("non-existent-agent")); // List reordered by constructor
         assertThat(parameterDefinition.getName(), is(name));
         assertThat(parameterDefinition.getDescription(), is(description));
@@ -175,7 +175,7 @@ class NodeParameterDefinitionTest {
 
         // Use reflection to access the method directly
         java.lang.reflect.Method m = NodeParameterDefinition.class.getDeclaredMethod(
-                "createValue", new Class[] { org.kohsuke.stapler.StaplerRequest2.class, net.sf.json.JSONObject.class });
+                "createValue", new Class[] {org.kohsuke.stapler.StaplerRequest2.class, net.sf.json.JSONObject.class});
         ParameterValue value1 = (ParameterValue) m.invoke(parameterDefinition, null, jo1);
 
         assertThat(value1, is(notNullValue()));
@@ -213,8 +213,8 @@ class NodeParameterDefinitionTest {
         allowedAgents.add(agent.getNodeName());
         String triggerIfResult = "triggerIfResult";
 
-        NodeParameterDefinition parameterDefinition = new NodeParameterDefinition(name, description, defaultAgents,
-                allowedAgents, triggerIfResult, true);
+        NodeParameterDefinition parameterDefinition =
+                new NodeParameterDefinition(name, description, defaultAgents, allowedAgents, triggerIfResult, true);
 
         // Verify the node eligibility was properly set
         assertThat(parameterDefinition.getNodeEligibility(), instanceOf(IgnoreOfflineNodeEligibility.class));
@@ -250,8 +250,8 @@ class NodeParameterDefinitionTest {
                 name, description, defaultAgents, allowedAgents, triggerIfResult, new AllNodeEligibility());
 
         NodeParameterValue defaultValue = parameterDefinition.getDefaultParameterValue();
-        NodeParameterDefinition copied = (NodeParameterDefinition) parameterDefinition
-                .copyWithDefaultValue(defaultValue);
+        NodeParameterDefinition copied =
+                (NodeParameterDefinition) parameterDefinition.copyWithDefaultValue(defaultValue);
 
         // Should return this
         assertEquals(parameterDefinition, copied);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
### Improved test coverage of org.jvnet.jenkins.plugins.nodelabelparameter

[JENKINS-69756](https://issues.jenkins.io/browse/JENKINS-69756?jql=labels%20%3D%20newbie-friendly%20and%20status%20in%20(Open%2C%20%22To%20Do%22%2C%20Reopened))

### Before

![image](https://github.com/user-attachments/assets/44d1f5f7-e9a6-4824-bb0f-839a3525f624)

### After

![image](https://github.com/user-attachments/assets/815feaf0-0af3-44eb-8186-80bfa31cf976)


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
