### PR TITLE
Feat/jenkins 69756 improved node label parameter plugin automated test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,12 @@
       <artifactId>throttle-concurrents</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.17.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/webapp/lib/nodelabel.js
+++ b/src/main/webapp/lib/nodelabel.js
@@ -29,7 +29,7 @@
 
 	ready(function () {
 		var concurrentBuild = document.querySelector("input[type='checkbox'][name='_.concurrentBuild']");
-		checkConcurrentExecutionValuesNode();
+		checkConcurrentExecutionsNode();
 		checkConcurrentExecutionValuesLabel();
 
 		concurrentBuild.addEventListener('change', function () {

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinitionTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinitionTest.java
@@ -33,6 +33,12 @@ class LabelParameterDefinitionTest {
     private static final String LABEL_NAME = "my-agent-label";
     private static final LabelAtom label = new LabelAtom(LABEL_NAME);
 
+    private static final String name = "name";
+    private static final String description = "The description";
+    private static final String defaultValue = "built-in || master";
+    private static final String triggerIfResult = "The triggerIfResult value";
+    private static final boolean allNodesMatchingLabel = true;
+
     @BeforeAll
     static void setUp(JenkinsRule rule) throws Exception {
         j = rule;
@@ -42,11 +48,6 @@ class LabelParameterDefinitionTest {
     @Test
     @Deprecated
     void testNodeParameterDefinitionDeprecated() {
-        String name = "name";
-        String description = "The description";
-        String defaultValue = "built-in || master";
-        String triggerIfResult = "The triggerIfResult value";
-
         LabelParameterDefinition nodeParameterDefinition =
                 new LabelParameterDefinition(name, description, defaultValue, true, true, triggerIfResult);
 
@@ -62,10 +63,6 @@ class LabelParameterDefinitionTest {
     @Test
     @Deprecated
     void testNodeParameterDefinitionDeprecated3Arg() {
-        String name = "name";
-        String description = "The description";
-        String defaultValue = "built-in || master";
-
         LabelParameterDefinition nodeParameterDefinition =
                 new LabelParameterDefinition(name, description, defaultValue);
 
@@ -80,11 +77,6 @@ class LabelParameterDefinitionTest {
 
     @Test
     void testNodeParameterDefinition() {
-        String name = "name";
-        String description = "The description";
-        String defaultValue = "built-in || master";
-        String triggerIfResult = "The triggerIfResult value";
-
         LabelParameterDefinition nodeParameterDefinition =
                 new LabelParameterDefinition(name, description, defaultValue, false, null, triggerIfResult);
 
@@ -157,12 +149,7 @@ class LabelParameterDefinitionTest {
 
     @Test
     void testCreateValue_WhenLabelIsMissingAndValueKeyIsUsed() {
-        String name = "name";
-        String description = "The description";
-        String defaultValue = "The value";
-        boolean allNodesMatchingLabel = true;
         NodeEligibility nodeEligibility = mock(NodeEligibility.class);
-        String triggerIfResult = "The triggerIfResult value";
 
         JSONObject jo = new JSONObject();
         jo.put("name", name);
@@ -179,19 +166,14 @@ class LabelParameterDefinitionTest {
 
         ParameterValue expectedValue = labelParameterDefinition.createValue(req, jo);
 
-        assertThat(labelParameterValue, is(expectedValue));
-        assertThat(labelParameterValue.getDescription(), is(expectedValue.getDescription()));
-        assertThat(labelParameterValue.getLabel(), is(((LabelParameterValue) expectedValue).getLabel()));
+        assertThat(expectedValue, is(labelParameterValue));
+        assertThat(expectedValue.getDescription(), is(labelParameterValue.getDescription()));
+        assertThat(((LabelParameterValue) expectedValue).getLabel(), is(labelParameterValue.getLabel()));
     }
 
     @Test
     void testCreateValue_BindsLabelFromLabelKeyCorrectly() {
-        String name = "name";
-        String description = "The description";
-        String defaultValue = "The value";
-        boolean allNodesMatchingLabel = true;
         NodeEligibility nodeEligibility = mock(NodeEligibility.class);
-        String triggerIfResult = "The triggerIfResult value";
 
         JSONObject jo = new JSONObject();
         jo.put("name", name);
@@ -209,8 +191,8 @@ class LabelParameterDefinitionTest {
 
         ParameterValue expectedValue = labelParameterDefinition.createValue(req, jo);
 
-        assertThat(labelParameterValue, is(expectedValue));
-        assertThat(labelParameterValue.getDescription(), is(expectedValue.getDescription()));
-        assertThat(labelParameterValue.getLabel(), is(((LabelParameterValue) expectedValue).getLabel()));
+        assertThat(expectedValue, is(labelParameterValue));
+        assertThat(expectedValue.getDescription(), is(labelParameterValue.getDescription()));
+        assertThat(((LabelParameterValue) expectedValue).getLabel(), is(labelParameterValue.getLabel()));
     }
 }

--- a/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinitionTest.java
+++ b/src/test/java/org/jvnet/jenkins/plugins/nodelabelparameter/LabelParameterDefinitionTest.java
@@ -1,10 +1,7 @@
 package org.jvnet.jenkins.plugins.nodelabelparameter;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -169,6 +166,7 @@ class LabelParameterDefinitionTest {
         assertThat(expectedValue, is(labelParameterValue));
         assertThat(expectedValue.getDescription(), is(labelParameterValue.getDescription()));
         assertThat(((LabelParameterValue) expectedValue).getLabel(), is(labelParameterValue.getLabel()));
+        assertThat(((LabelParameterValue) expectedValue).getNextLabels(), is(notNullValue()));
     }
 
     @Test
@@ -194,5 +192,6 @@ class LabelParameterDefinitionTest {
         assertThat(expectedValue, is(labelParameterValue));
         assertThat(expectedValue.getDescription(), is(labelParameterValue.getDescription()));
         assertThat(((LabelParameterValue) expectedValue).getLabel(), is(labelParameterValue.getLabel()));
+        assertThat(((LabelParameterValue) expectedValue).getNextLabels(), is(notNullValue()));
     }
 }


### PR DESCRIPTION
### Testing done
Fixes JENKINS-69756

This change specifically enhances unit test coverage for the **`createValue` method within the `LabelParameterDefinition` class.**

The updated test methods, `testCreateValue_WhenLabelIsMissingAndValueKeyIsUsed()` and `testCreateValue_BindsLabelFromLabelKeyCorrectly()`

### Before
<img width="1374" height="191" alt="e1" src="https://github.com/user-attachments/assets/6dbe5991-109e-40c4-b40f-e964c11adcb3" />
<img width="1351" height="363" alt="e2" src="https://github.com/user-attachments/assets/5123f665-f5f0-484d-aef5-a1cc9a87720f" />
<img width="1339" height="380" alt="e3" src="https://github.com/user-attachments/assets/83fec7a0-3736-47bb-a1a9-e16e3739aa12" />

### After
<img width="1371" height="186" alt="y1" src="https://github.com/user-attachments/assets/656a89c4-63bc-4074-8397-656e30322e16" />
<img width="1345" height="357" alt="y2" src="https://github.com/user-attachments/assets/50d4d239-e313-4144-9637-ebf5ebd11f5b" />
<img width="1339" height="385" alt="y3" src="https://github.com/user-attachments/assets/af2791e7-c4fb-4e09-864e-8a072c757e0a" />

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
